### PR TITLE
Add the tag sorting decorator with custom plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The [custom plugin](https://redocly.com/docs/cli/custom-plugins/) is the ultimat
 
 #### Decorators (for custom plugins)
 
+* [Tag sorting](./custom-plugin-decorators/tag-sorting) - put your tags list in alphabetical order.
+
 #### Rules (for custom plugins)
 
 ### Miscellaneous (including tips and tricks)

--- a/custom-plugin-decorators/tag-sorting/README.md
+++ b/custom-plugin-decorators/tag-sorting/README.md
@@ -1,0 +1,95 @@
+# Decorator to sort tags in an API description
+
+Authors:
+- [`@lornajane`](https://github.com/lornajane), Lorna Mitchell (Redocly)
+ 
+## What this does and why
+
+Redocly CLI has the [`tags-alphabetical'](https://redocly.com/docs/cli/rules/tags-alphabetical/) rule to error if the `tags` section isn't in alphabetical order by `name`.
+
+This decorator provides functionality to _put_ the tags in order by name, in order to make any API description compatible with that rule.
+
+## Code
+
+Here's the main plugin entrypoint, it's in `tag-sorting.js`:
+
+```javascript
+
+const SortTagsAlphabetically = require('./decorator-alpha.js');
+
+module.exports = {
+  id: 'tag-sorting',
+  decorators: {
+    oas3: {
+      'alphabetical': SortTagsAlphabetically,
+    }
+  }
+	
+}
+```
+
+The code here sets the plugin name to `tag-sorting` and adds a decorator for OpenAPI 3 called `alphabetical`.
+
+The functionality for the alphabetical sorting is in `decorator-alpha.js`:
+
+```javascript
+
+module.exports = SortTagsAlphabetically;
+
+function SortTagsAlphabetically() {
+  console.log("re-ordering tags: alphabetical");
+  return {
+    TagList: {
+      leave(target) {
+        target.sort((a,b) => {
+          if (a.name < b.name) {
+            return -1;
+          }
+        });
+      }
+    }
+  }
+}
+```
+
+It operates on the `TagList` element, since it needs to shuffle the child entries inside it. A simple comparison of the name field is used to sort the items.
+
+## Examples
+
+Add the plugin to `redocly.yaml` and enable the decorator:
+
+```yaml
+plugins:
+  - 'plugins/tag-sorting.js'
+
+decorators:
+  tag-sorting/alphabetical: on
+```
+
+Now with an OpenAPI description that has more than one tag listed at the top level, the decorator will re-order the entries.
+
+**Before**:
+
+```yaml
+tags:
+  - name: user
+    description: Users
+  - name: site
+    description: Restaurant sites
+```
+
+**After**:
+
+```yaml
+tags:
+  - name: site
+    description: Restaurant sites
+  - name: user
+    description: Users
+```
+
+## References
+
+* [`tags-alphabetical' rule](https://redocly.com/docs/cli/rules/tags-alphabetical/)
+* The [`tags` types documentation](https://redocly.com/docs/openapi-visual-reference/tags/#types)
+

--- a/custom-plugin-decorators/tag-sorting/README.md
+++ b/custom-plugin-decorators/tag-sorting/README.md
@@ -15,7 +15,7 @@ Here's the main plugin entrypoint, it's in `tag-sorting.js`:
 
 ```javascript
 
-const SortTagsAlphabetically = require('./decorator-alpha.js');
+const SortTagsAlphabetically = require('./decorator-alpha');
 
 module.exports = {
   id: 'tag-sorting',
@@ -60,7 +60,7 @@ Add the plugin to `redocly.yaml` and enable the decorator:
 
 ```yaml
 plugins:
-  - 'plugins/tag-sorting.js'
+  - './tag-sorting.js'
 
 decorators:
   tag-sorting/alphabetical: on

--- a/custom-plugin-decorators/tag-sorting/decorator-alpha.js
+++ b/custom-plugin-decorators/tag-sorting/decorator-alpha.js
@@ -1,0 +1,16 @@
+module.exports = SortTagsAlphabetically;
+
+function SortTagsAlphabetically() {
+  console.log("re-ordering tags: alphabetical");
+  return {
+    TagList: {
+      leave(target) {
+        target.sort((a,b) => {
+          if (a.name < b.name) {
+            return -1;
+          }
+        });
+      }
+    }
+  }
+}

--- a/custom-plugin-decorators/tag-sorting/tag-sorting.js
+++ b/custom-plugin-decorators/tag-sorting/tag-sorting.js
@@ -1,0 +1,11 @@
+const SortTagsAlphabetically = require('./decorator-alpha.js');
+
+module.exports = {
+  id: 'tag-sorting',
+  decorators: {
+    oas3: {
+      'alphabetical': SortTagsAlphabetically,
+    }
+  }
+	
+}

--- a/custom-plugin-decorators/tag-sorting/tag-sorting.js
+++ b/custom-plugin-decorators/tag-sorting/tag-sorting.js
@@ -1,4 +1,4 @@
-const SortTagsAlphabetically = require('./decorator-alpha.js');
+const SortTagsAlphabetically = require('./decorator-alpha');
 
 module.exports = {
   id: 'tag-sorting',


### PR DESCRIPTION
Added a custom plugin with a decorator to sort the tags list alphabetically. We have a rule to check the order, but this adds the ability to fix it!