### PR TITLE
Configure a rule to ban specific words from being used in descriptions

### DIFF
--- a/configurable-rules/description-banned-words/README.md
+++ b/configurable-rules/description-banned-words/README.md
@@ -1,0 +1,41 @@
+# Ban certain words from descriptions
+
+Authors:
+- [`@lornajane`](https://github.com/lornajane) Lorna Mitchell (Redocly) 
+
+## What this does and why
+
+There are some words that just should not appear in `description` fields, but somehow they crop up time and time again. Eliminate them with this configurable rule that will error if they are used.
+
+**Tip:** If there's a false positive, consider using the [ignore file](https://redocly.com/docs/cli/commands/lint/#generate-ignore-file) to skip that specific occurrence and keep the rule in place for everything else.
+
+## Code
+
+An example of `redocly.yaml` with a configurable rule:
+
+```yaml
+rules:
+  rule/descriptions-avoid-words:
+    subject:
+      type: any
+      property: description
+    assertions:
+      notPattern: /(simple|random|just)/i
+```
+
+Edit the `notPattern` section to add as many pipe-separated terms as you'd like to exclude.
+
+## Examples
+
+Acceptable description field:
+
+```yaml
+      description: Fetch all registered users in a collection.
+```
+
+Unacceptable description field (but choose your own banned words):
+
+```yaml
+      description: Fetch all registered users in a simple collection.
+```
+

--- a/configurable-rules/description-banned-words/redocly.yaml
+++ b/configurable-rules/description-banned-words/redocly.yaml
@@ -1,0 +1,8 @@
+rules:
+  rule/avoid-words-in-descriptions:
+    subject:
+      type: any
+      property: description
+    assertions:
+      notPattern: /(waffle|mumble|squeak)/i
+


### PR DESCRIPTION
Just as it says on the tin: use `notPattern` with Description elements to stop certain words from being used.