### PR TITLE
docs: add custom decorator update-example-dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The [custom plugin](https://redocly.com/docs/cli/custom-plugins/) is the ultimat
 
 - [Tag sorting](./custom-plugin-decorators/tag-sorting) - put your tags list in alphabetical order.
 
-- [Update example dates](./custom-plugin-decorators/update-example-dates) - update dates in examples to the current date.
+- [Substitute datetime placeholders in an API description](./custom-plugin-decorators/update-example-dates) - update dates in examples to the current date.
 
 #### Rules (for custom plugins)
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The [custom plugin](https://redocly.com/docs/cli/custom-plugins/) is the ultimat
 
 - [Tag sorting](./custom-plugin-decorators/tag-sorting) - put your tags list in alphabetical order.
 
+- [Update example dates](./custom-plugin-decorators/update-example-dates) - update dates in examples to the current date.
+
 #### Rules (for custom plugins)
 
 - [Validate Markdown](./custom-plugin-rules/markdown-validator) - check Markdown in description fields is valid.

--- a/custom-plugin-decorators/update-example-dates/README.md
+++ b/custom-plugin-decorators/update-example-dates/README.md
@@ -1,0 +1,125 @@
+# Decorator to substitute date templates in an API description
+
+Authors:
+
+- [`@tatomyr`](https://github.com/tatomyr), Andrew Tatomyr (Redocly)
+
+## What this does and why
+
+When rendering an API description it might be useful to use current dates in examples.
+Let's say, we want to use a special datetime template, like `$DateTimeNow + 10 days` where the `$DateTimeNow` variable stands for the current date. Also, let's use only the `+` operator for the sake of simplicity.
+
+This decorator provides functionality to substitute the basic date templates with the actual values when bundling an API description.
+
+## Code
+
+The `date-time` plugin only defines the `decorator` section and the plugin `id`:
+
+```javascript
+const updateExampleDates = require("./decorator");
+
+module.exports = {
+  id: "dates-plugin",
+  decorators: {
+    oas3: {
+      "update-example-dates": updateExampleDates,
+    },
+  },
+};
+```
+
+Here's the main part of the decorator:
+
+```javascript
+function updateExampleDates() {
+  return {
+    // Covers the 'examples' keyword (including examples in the 'components' section)
+    Example: {
+      enter(example) {
+        traverseAndReplaceWithComputedDateTime(example.value);
+      },
+    },
+    // Covers the 'example' in media type objects
+    MediaType: {
+      enter(mediaTypeObject) {
+        if (mediaTypeObject.example) {
+          traverseAndReplaceWithComputedDateTime(mediaTypeObject.example);
+        }
+      },
+    },
+    // Covers the 'example' in schemas
+    Schema: {
+      enter(schema) {
+        if (schema.example) {
+          traverseAndReplaceWithComputedDateTime(schema);
+        }
+      },
+    },
+  };
+}
+```
+
+It operates on the `Example`, `MediaType` and `Schema` nodes to cover the different ways of specifying examples (see the [specification](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object)).
+
+The `traverseAndReplaceWithComputedDateTime` function traverses the tree of nodes and replaces the values that contain the specific `$DateTimeNow` variable in examples with a computed datetime value:
+
+```javascript
+function traverseAndReplaceWithComputedDateTime(value) {
+  if (typeof value === "object" && value !== null) {
+    for (const key in value) {
+      if (typeof value[key] === "string" && /\$DateTimeNow/.test(value[key])) {
+        // Replacing the template with a computed datetime value
+        value[key] = computeDateTemplate(value[key]);
+      } else {
+        traverseAndReplaceWithComputedDateTime(value[key]);
+      }
+    }
+  }
+}
+```
+
+In this example we'll consider a very basic datetime calculator that can only add days to the current date, but it should be enough to illustrate the idea:
+
+```javascript
+function computeDateTemplate(template) {
+  const substitutedExpression = template
+    .replace("$DateTimeNow", Date.now()) // Replacing the variable with the current date in milliseconds
+    .replace(/(\d+)\s*days?/g, (_, t) => t * 1000 * 60 * 60 * 24) // Replacing days with milliseconds
+    .trim();
+  const calculated = substitutedExpression // A basic calculator
+    .split(/\s*\+\s*/)
+    .reduce((sum, item) => sum + +item, 0);
+  return new Date(calculated).toISOString();
+}
+```
+
+## Examples
+
+Add the plugin to `redocly.yaml` and enable the decorator:
+
+```yaml
+plugins:
+  - ./plugin.js
+
+decorators:
+  dates-plugin/update-example-dates: on
+```
+
+Given the following API description, the decorator will replace `$DateTimeNow` with the current date and `$DateTimeNow + 7d` with the date in a week:
+
+```yaml
+openapi: 3.1.0
+paths:
+  /date-time:
+    get:
+      responses:
+        200:
+          content:
+            application/json:
+              example:
+                somewhere-in-the-past: 2023-11-06T12:00:00.000Z
+                today: $DateTimeNow # Will be replaced with the current date
+                in-a-week: $DateTimeNow + 7 days # Will be replaced with the date in a week
+```
+
+Please note that API descriptions are static text documents, so the dates will get updated only when the description gets bundled.

--- a/custom-plugin-decorators/update-example-dates/README.md
+++ b/custom-plugin-decorators/update-example-dates/README.md
@@ -1,4 +1,4 @@
-# Decorator to substitute date templates in an API description
+# Substitute datetime placeholders in an API description
 
 Authors:
 
@@ -6,14 +6,16 @@ Authors:
 
 ## What this does and why
 
-When rendering an API description it might be useful to use current dates in examples.
-Let's say, we want to use a special datetime template, like `$DateTimeNow + 10 days` where the `$DateTimeNow` variable stands for the current date. Also, let's use only the `+` operator for the sake of simplicity.
+When an API description includes datetime values, it's nice if they present soon or realistic date values.
+This decorator provides the functionality to replace a special datetime placeholder, `$DateTimeNow`, with the current date and time when bundling the API description.
+You can also use expressions to add a set number of days to the value, for example `$DateTimeNow + 10 days`.
 
-This decorator provides functionality to substitute the basic date templates with the actual values when bundling an API description.
+> [!WARNING]
+> Placeholders aren't supported by all OpenAPI tools. Using this approach, you should bundle your OpenAPI to apply the decorators before passing the API description to other tools.
 
 ## Code
 
-The `date-time` plugin only defines the `decorator` section and the plugin `id`:
+The `dates-plugin` plugin defines the `decorator` section and the plugin `id`:
 
 ```javascript
 const updateExampleDates = require("./decorator");
@@ -28,7 +30,7 @@ module.exports = {
 };
 ```
 
-Here's the main part of the decorator:
+Here's the main part of the decorator (from `decorator.js`):
 
 ```javascript
 function updateExampleDates() {
@@ -59,7 +61,7 @@ function updateExampleDates() {
 }
 ```
 
-It operates on the `Example`, `MediaType` and `Schema` nodes to cover the different ways of specifying examples.
+The decorator operates on the `Example`, `MediaType` and `Schema` nodes to cover the different ways of specifying examples.
 
 The `traverseAndReplaceWithComputedDateTime` function traverses the tree of nodes and replaces the values that contain the specific `$DateTimeNow` variable in examples with a computed datetime value:
 
@@ -78,7 +80,7 @@ function traverseAndReplaceWithComputedDateTime(value) {
 }
 ```
 
-In this example we'll consider a very basic datetime calculator that can only add days to the current date, but it should be enough to illustrate the idea:
+The `computeDateTemplate` function is a very basic datetime calculator that can only add days to the current date, but it illustrates the idea and you can extend it to meet your own specific needs:
 
 ```javascript
 function computeDateTemplate(template) {
@@ -105,7 +107,7 @@ decorators:
   dates-plugin/update-example-dates: on
 ```
 
-Given the following API description, the decorator will replace `$DateTimeNow` with the current date and `$DateTimeNow + 7d` with the date in a week:
+Given the following API description, the decorator will replace `$DateTimeNow` with the current date and `$DateTimeNow + 7d` with the date a week from now:
 
 ```yaml
 openapi: 3.1.0
@@ -126,6 +128,6 @@ Please note that API descriptions are static text documents, so the dates will g
 
 ## References
 
-- [Redocly docs on examples](https://redocly.com/docs/openapi-visual-reference/schemas/#example-and-examples)
+- [Redocly documentation on examples in OpenAPI](https://redocly.com/docs/openapi-visual-reference/schemas/#example-and-examples)
 
 - [OpenAPI Specification on Media Type Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object)

--- a/custom-plugin-decorators/update-example-dates/README.md
+++ b/custom-plugin-decorators/update-example-dates/README.md
@@ -59,7 +59,7 @@ function updateExampleDates() {
 }
 ```
 
-It operates on the `Example`, `MediaType` and `Schema` nodes to cover the different ways of specifying examples (see the [specification](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object)).
+It operates on the `Example`, `MediaType` and `Schema` nodes to cover the different ways of specifying examples.
 
 The `traverseAndReplaceWithComputedDateTime` function traverses the tree of nodes and replaces the values that contain the specific `$DateTimeNow` variable in examples with a computed datetime value:
 
@@ -123,3 +123,9 @@ paths:
 ```
 
 Please note that API descriptions are static text documents, so the dates will get updated only when the description gets bundled.
+
+## References
+
+- [Redocly docs on examples](https://redocly.com/docs/openapi-visual-reference/schemas/#example-and-examples)
+
+- [OpenAPI Specification on Media Type Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object)

--- a/custom-plugin-decorators/update-example-dates/decorator.js
+++ b/custom-plugin-decorators/update-example-dates/decorator.js
@@ -1,0 +1,52 @@
+function updateExampleDates() {
+  return {
+    // Covers the 'examples' keyword (including examples in the 'components' section)
+    Example: {
+      enter(example) {
+        traverseAndReplaceWithComputedDateTime(example.value);
+      },
+    },
+    // Covers the 'example' in media type objects
+    MediaType: {
+      enter(mediaTypeObject) {
+        if (mediaTypeObject.example) {
+          traverseAndReplaceWithComputedDateTime(mediaTypeObject.example);
+        }
+      },
+    },
+    // Covers the 'example' in schemas
+    Schema: {
+      enter(schema) {
+        if (schema.example) {
+          traverseAndReplaceWithComputedDateTime(schema);
+        }
+      },
+    },
+  };
+}
+
+function traverseAndReplaceWithComputedDateTime(value) {
+  if (typeof value === "object" && value !== null) {
+    for (const key in value) {
+      if (typeof value[key] === "string" && /\$DateTimeNow/.test(value[key])) {
+        // Replacing the template with a computed datetime value
+        value[key] = computeDateTemplate(value[key]);
+      } else {
+        traverseAndReplaceWithComputedDateTime(value[key]);
+      }
+    }
+  }
+}
+
+function computeDateTemplate(template) {
+  const substitutedExpression = template
+    .replace("$DateTimeNow", Date.now()) // Replacing the variable with the current date in milliseconds
+    .replace(/(\d+)\s*days?/g, (_, t) => t * 1000 * 60 * 60 * 24) // Replacing days with milliseconds
+    .trim();
+  const calculated = substitutedExpression // A basic calculator
+    .split(/\s*\+\s*/)
+    .reduce((sum, item) => sum + +item, 0);
+  return new Date(calculated).toISOString();
+}
+
+module.exports = updateExampleDates;

--- a/custom-plugin-decorators/update-example-dates/plugin.js
+++ b/custom-plugin-decorators/update-example-dates/plugin.js
@@ -1,0 +1,8 @@
+const updateExampleDates = require('./decorator');
+
+module.exports = {
+  id: 'dates-plugin',
+  decorators: { oas3: {
+    'update-example-dates': updateExampleDates
+  }},
+};

--- a/custom-plugin-decorators/update-example-dates/plugin.js
+++ b/custom-plugin-decorators/update-example-dates/plugin.js
@@ -1,8 +1,10 @@
-const updateExampleDates = require('./decorator');
+const updateExampleDates = require("./decorator");
 
 module.exports = {
-  id: 'dates-plugin',
-  decorators: { oas3: {
-    'update-example-dates': updateExampleDates
-  }},
+  id: "dates-plugin",
+  decorators: {
+    oas3: {
+      "update-example-dates": updateExampleDates,
+    },
+  },
 };


### PR DESCRIPTION
A custom decorator to substitute simple datetime templates in examples.