### PR TITLE
Add info-description equivalent as a configurable rule, credit to Adam

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ There are some fantastic examples of [configurable rules](https://redocly.com/do
 - [`POST` SHOULD define `requestBody` schema](configurable-rules/operation-post-should-define-request-body/)
 - [`GET` SHOULD NOT define `requestBody` schema](configurable-rules/operation-get-should-not-define-requestBody/)
 - [`DELETE` SHOULD NOT define `requestBody` schema](configurable-rules/operation-delete-should-not-define-requestBody/)
+- [Info section must have a description](configurable-rules/info-description)
 
 ### Custom plugins
 

--- a/configurable-rules/info-description/README.md
+++ b/configurable-rules/info-description/README.md
@@ -1,0 +1,47 @@
+# Info must include Description
+
+Authors:
+- [`@adamaltman`](https://github.com/adamaltman), Adam Altman (Redocly)
+ 
+## What this does and why
+
+Ensures that the `info` section includes a `description` field. Including good metadata with your API can help discoverability, so you might like to include this rule in your ruleset.
+
+This rule is an equivalent to Spectral's `info-description` rule, easily expressed in Redocly configurable rule syntax.
+
+## Code
+
+Configured in `redocly.yanl`, like this:
+
+```yaml
+rules:
+  rule/info-description:
+    subject:
+      type: Info
+      property: description
+    assertions:
+      defined: true
+```
+
+## Examples
+
+An OpenAPI specification without a `description` in `info` will cause an error:
+
+```
+openapi: 3.1.0
+info:
+  title: A non-descriptive API
+paths: {}
+```
+
+Will give an error:
+
+```text
+rule/info-description failed because the Info description didn't meet the assertions: Should be defined
+```
+
+If you add a description, the check will pass.
+
+## References
+
+- [Spectral's info-description rule](https://docs.stoplight.io/docs/spectral/4dec24461f3af-open-api-rules#info-description)

--- a/configurable-rules/info-description/README.md
+++ b/configurable-rules/info-description/README.md
@@ -11,7 +11,7 @@ This rule is an equivalent to Spectral's `info-description` rule, easily express
 
 ## Code
 
-Configured in `redocly.yanl`, like this:
+Configured in `redocly.yaml`, like this:
 
 ```yaml
 rules:
@@ -27,7 +27,7 @@ rules:
 
 An OpenAPI specification without a `description` in `info` will cause an error:
 
-```
+```yaml
 openapi: 3.1.0
 info:
   title: A non-descriptive API

--- a/configurable-rules/info-description/redocly.yaml
+++ b/configurable-rules/info-description/redocly.yaml
@@ -1,0 +1,8 @@
+rules:
+  rule/info-description:
+    subject:
+      type: Info
+      property: description
+    assertions:
+      defined: true
+


### PR DESCRIPTION
From https://github.com/Redocly/redocly-cli/issues/1177, add the info-description as a cookbook entry