### PR TITLE
Add the no-script-in-markdown spectral equivalent rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ There are some fantastic examples of [configurable rules](https://redocly.com/do
 - [`GET` SHOULD NOT define `requestBody` schema](configurable-rules/operation-get-should-not-define-requestBody/)
 - [`DELETE` SHOULD NOT define `requestBody` schema](configurable-rules/operation-delete-should-not-define-requestBody/)
 - [Info section must have a description](configurable-rules/info-description)
+- [No `<script>` tags in descriptions](configurable-rules/no-script)
 
 ### Custom plugins
 

--- a/configurable-rules/no-script/README.md
+++ b/configurable-rules/no-script/README.md
@@ -1,0 +1,50 @@
+# Detect `<script>` tags in Markdown descriptions
+
+Authors:
+- [`@adamaltman`](https://github.com/adamaltman), Adam Altman (Redocly)
+- [`@lornajane`](https://github.com/lornajane), Lorna Mitchell (Redocly)
+ 
+
+## What this does and why
+
+Detects use of `<script>` tags in Markdown description fields. Since Markdown also supports HTML, if you are bringing APIs in and displaying them then you probably want to be sure that script tags are not included since they can include harmful content.
+
+## Code
+
+In `redocly.yaml`, configure the rule like this:
+
+```yaml
+rules:
+  rule/no-script-tags-in-markdown:
+    subject:
+      type: any
+      property: description
+    assertions:
+      notPattern: '<script'
+    severity: warn
+    message: Markdown descriptions should not contain script tags.
+```
+
+This will pick up the contents of any `description` field in an OpenAPI file and warn you with a coherent message if there's a script tag found.
+
+## Examples
+
+Here's a mini OpenAPI description, with a script tag in the `info.description` field:
+
+```yaml
+openapi: 3.1.0
+info:
+  title: Great API
+  description: This is an excellent <script>alert("Tricked you!");</script> API
+paths: {}
+```
+
+When you lint this OpenAPI file with the `rule/no-script-tags-in-markdown` rule, you'll see a warning:
+
+```text
+Markdown descriptions should not contain script tags.
+```
+
+## References
+
+Inspired by the Spectral rule [no-script-tags-in-markdown](https://docs.stoplight.io/docs/spectral/4dec24461f3af-open-api-rules#no-script-tags-in-markdown).

--- a/configurable-rules/no-script/redocly.yaml
+++ b/configurable-rules/no-script/redocly.yaml
@@ -1,0 +1,11 @@
+extends: []
+
+rules:
+  rule/no-script-tags-in-markdown:
+    subject:
+      type: any
+      property: description
+    assertions:
+      notPattern: '<script'
+    severity: warn
+    message: Markdown descriptions should not contain script tags.


### PR DESCRIPTION
(this is for AdventOfAPILint, if anyone has time to review soonish!)

From @adamaltman 's collection of Spectral-equivalent rules, this one checks for `<script` tags in any description field.

See also: https://github.com/Redocly/redocly-cli/issues/1177