### PR TITLE
add the configurable rule replacement for the path-excludes-patterns rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ There are some fantastic examples of [configurable rules](https://redocly.com/do
 - [`DELETE` SHOULD NOT define `requestBody` schema](configurable-rules/operation-delete-should-not-define-requestBody/)
 - [Info section must have a description](configurable-rules/info-description)
 - [No `<script>` tags in descriptions](configurable-rules/no-script)
+- [Paths should not match a pattern](configurable-rules/path-excludes-pattern/)
 
 ### Custom plugins
 

--- a/configurable-rules/path-excludes-pattern/README.md
+++ b/configurable-rules/path-excludes-pattern/README.md
@@ -45,4 +45,4 @@ paths:
 
 ## References
 
-Built-in [`no-http-verbs-in-paths` rule](https://redocly.com/docs/cli/rules/no-http-verbs-in-paths/#no-http-verbs-in-paths) .
+Built-in [`no-http-verbs-in-paths` rule](https://redocly.com/docs/cli/rules/no-http-verbs-in-paths/#no-http-verbs-in-paths).

--- a/configurable-rules/path-excludes-pattern/README.md
+++ b/configurable-rules/path-excludes-pattern/README.md
@@ -1,0 +1,48 @@
+# Paths should not match a pattern
+
+Authors:
+
+- [`@tatomyr`](https://github.com/tatomyr) Andrew Tatomyr (Redocly)
+
+## What this does and why
+
+The [`no-http-verbs-in-paths` rule](https://redocly.com/docs/cli/rules/no-http-verbs-in-paths/#no-http-verbs-in-paths) is pre-built for a very specific set of patterns.
+This rule is the general Swiss army knife version.
+If you absolutely know something should not be in the path (for example `foo`), then add the pattern to prevent it.
+
+Some common things to check using this rule: other common CRUD verbs, bad words, and internal code or terminology.
+
+## Code
+
+Add this to the `rules` section of your `redocly.yaml`:
+
+```yaml
+rules:
+  rule/path-exclude-pattern:
+    subject:
+      type: Paths
+    assertions:
+      notPattern: \/wrong
+```
+
+If you want to exclude multiple patterns, you may write several rules like this each with a different pattern.
+
+## Examples
+
+Here's an example of an OpenAPI description:
+
+```yaml
+openapi: 3.1.0
+info:
+  title: Title
+  version: 1.0.0
+paths:
+  /good:
+    $ref: ./good.yaml
+  /wrong: # <-- This will error
+    $ref: ./wrong.yaml
+```
+
+## References
+
+Built-in [`no-http-verbs-in-paths` rule](https://redocly.com/docs/cli/rules/no-http-verbs-in-paths/#no-http-verbs-in-paths) .

--- a/configurable-rules/path-excludes-pattern/redocly.yaml
+++ b/configurable-rules/path-excludes-pattern/redocly.yaml
@@ -1,0 +1,6 @@
+rules:
+  rule/path-exclude-pattern:
+    subject:
+      type: Paths
+    assertions:
+      notPattern: \/wrong


### PR DESCRIPTION
Copypasted the [path-excludes-patterns](https://redocly.com/docs/cli/rules/no-http-verbs-in-paths/#no-http-verbs-in-paths) rule docs. If we deprecate the original rule, we can put a link to this docs.