### PR TITLE
Change markdownlint to use the sync version

### DIFF
--- a/custom-plugin-rules/markdown-validator/README.md
+++ b/custom-plugin-rules/markdown-validator/README.md
@@ -78,20 +78,20 @@ function checkString(description, ctx) {
       // desc is the key in the options.strings object
       let lines = description.split("\n");
 
-      lintResults.desc.forEach((desc) => {
+      for (const desc of lintResults.desc) {
         // grab error message
         let message = desc.ruleDescription;
         // add line number context for longer entries
         if (desc.lineNumber > 1) {
           const charsByError = lines[desc.lineNumber].substring(0, 20);
-          message = `${message} (near: ${charsByError}...)`
+          message = `${message} (near: ${charsByError} ...)`
         }
 
         ctx.report({
           message: message,
           location: ctx.location.child("description"),
         });
-      })
+      }
     }
   } catch (error) {
     console.log(error);

--- a/custom-plugin-rules/markdown-validator/README.md
+++ b/custom-plugin-rules/markdown-validator/README.md
@@ -70,32 +70,32 @@ function checkString(description, ctx) {
     },
     config: config,
   };
-  markdownlint(options, function callback(err, result) {
-    if (!err) {
-      // if there's no problem do nothing
-      if (result.desc.length) {
-        // desc is the key in the options.strings object
-        let lines = description.split("\n");
 
-        result.desc.forEach((desc) => {
-          message = desc.ruleDescription;
-          // add line number context for longer entries
-          if (desc.lineNumber > 1) {
-            message =
-              message +
-              " (near: " +
-              lines[desc.lineNumber].substring(0, 20) +
-              "... )";
-          }
+  try {
+    const lintResults = markdownlint.sync(options);
+    
+    if (lintResults.desc.length) {
+      // desc is the key in the options.strings object
+      let lines = description.split("\n");
 
-          ctx.report({
-            message: message,
-            location: ctx.location.child("description"),
-          });
+      lintResults.desc.forEach((desc) => {
+        // grab error message
+        let message = desc.ruleDescription;
+        // add line number context for longer entries
+        if (desc.lineNumber > 1) {
+          const charsByError = lines[desc.lineNumber].substring(0, 20);
+          message = `${message} (near: ${charsByError}...)`
+        }
+
+        ctx.report({
+          message: message,
+          location: ctx.location.child("description"),
         });
-      }
+      })
     }
-  });
+  } catch (error) {
+    console.log(error);
+  }
 }
 
 function ValidateMarkdown() {

--- a/custom-plugin-rules/markdown-validator/rule-validate-markdown.js
+++ b/custom-plugin-rules/markdown-validator/rule-validate-markdown.js
@@ -21,20 +21,20 @@ function checkString(description, ctx) {
       // desc is the key in the options.strings object
       let lines = description.split("\n");
 
-      lintResults.desc.forEach((desc) => {
+      for (const desc of lintResults.desc){
         // grab error message
         let message = desc.ruleDescription;
         // add line number context for longer entries
         if (desc.lineNumber > 1) {
           const charsByError = lines[desc.lineNumber].substring(0, 20);
-          message = `${message} (near: ${charsByError}...)`
+          message = `${message} (near: ${charsByError} ...)`
         }
 
         ctx.report({
           message: message,
           location: ctx.location.child("description"),
         });
-      })
+      }
     }
   } catch (error) {
     console.log(error);

--- a/custom-plugin-rules/markdown-validator/rule-validate-markdown.js
+++ b/custom-plugin-rules/markdown-validator/rule-validate-markdown.js
@@ -13,32 +13,32 @@ function checkString(description, ctx) {
     },
     config: config,
   };
-  markdownlint(options, function callback(err, result) {
-    if (!err) {
-      // if there's no problem do nothing
-      if (result.desc.length) {
-        // desc is the key in the options.strings object
-        let lines = description.split("\n");
 
-        result.desc.forEach((desc) => {
-          message = desc.ruleDescription;
-          // add line number context for longer entries
-          if (desc.lineNumber > 1) {
-            message =
-              message +
-              " (near: " +
-              lines[desc.lineNumber].substring(0, 20) +
-              "... )";
-          }
+  try {
+    const lintResults = markdownlint.sync(options);
+    
+    if (lintResults.desc.length) {
+      // desc is the key in the options.strings object
+      let lines = description.split("\n");
 
-          ctx.report({
-            message: message,
-            location: ctx.location.child("description"),
-          });
+      lintResults.desc.forEach((desc) => {
+        // grab error message
+        let message = desc.ruleDescription;
+        // add line number context for longer entries
+        if (desc.lineNumber > 1) {
+          const charsByError = lines[desc.lineNumber].substring(0, 20);
+          message = `${message} (near: ${charsByError}...)`
+        }
+
+        ctx.report({
+          message: message,
+          location: ctx.location.child("description"),
         });
-      }
+      })
     }
-  });
+  } catch (error) {
+    console.log(error);
+  }
 }
 
 function ValidateMarkdown() {

--- a/custom-plugin-rules/markdown-validator/rule-validate-markdown.js
+++ b/custom-plugin-rules/markdown-validator/rule-validate-markdown.js
@@ -21,7 +21,7 @@ function checkString(description, ctx) {
       // desc is the key in the options.strings object
       let lines = description.split("\n");
 
-      for (const desc of lintResults.desc){
+      for (const desc of lintResults.desc) {
         // grab error message
         let message = desc.ruleDescription;
         // add line number context for longer entries


### PR DESCRIPTION
Minor changes to the markdown-validator in the custom-plugin-rules folder. The behavior is the same, but the markdownlint tool now uses the syncronous API. I tested locally to verify.