### PR TITLE
Fix an off-by-one on the line numbers that was causing last-line errors

### DIFF
--- a/custom-plugin-rules/markdown-validator/rule-validate-markdown.js
+++ b/custom-plugin-rules/markdown-validator/rule-validate-markdown.js
@@ -26,7 +26,8 @@ function checkString(description, ctx) {
         let message = desc.ruleDescription;
         // add line number context for longer entries
         if (desc.lineNumber > 1) {
-          const charsByError = lines[desc.lineNumber].substring(0, 20);
+          // computer counts from zero, humans count from 1
+          const charsByError = lines[desc.lineNumber - 1].substring(0, 20);
           message = `${message} (near: ${charsByError} ...)`
         }
 


### PR DESCRIPTION
I was getting some stack trace output and noticed it was always the last line of the description field - and that all the other messages seemed slightly off too. I don't know how we didn't catch it earlier, but the line numbers thing starts from one but the split lines start from zero! This fixes it :)