### PR TITLE
update the `required-items-in-array-schemas` configurable rule

### DIFF
--- a/configurable-rules/required-items-for-array-schemas/README.md
+++ b/configurable-rules/required-items-for-array-schemas/README.md
@@ -30,11 +30,13 @@ rules:
           property: type
         assertions:
           const: array
+          defined: true
     message: The 'items' field is required for schemas of array type.
 ```
 
 This rule will error if an array is declared without an `items` field.
-Note how the `where` section is used to filter the rule to only apply to schemas of type `array`.
+The `where` section is used to filter the rule to only apply to schemas of type `array`.
+Note the `defined: true` assertion, which ensures that the `type` field is defined.
 
 ## Examples
 

--- a/configurable-rules/required-items-for-array-schemas/redocly.yaml
+++ b/configurable-rules/required-items-for-array-schemas/redocly.yaml
@@ -11,4 +11,5 @@ rules:
           property: type
         assertions:
           const: array
+          defined: true
     message: The 'items' field is required for schemas of array type.


### PR DESCRIPTION
Updated the `required-items-in-array-schemas` configurable rule based on this: https://github.com/Redocly/redocly-cli-cookbook/issues/30
Kudos to @icholy for the original issue