### PR TITLE
Add configurable rule for strict string definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ There are some fantastic examples of [configurable rules](https://redocly.com/do
 - [No `<script>` tags in descriptions](configurable-rules/no-script)
 - [Paths should not match a pattern](configurable-rules/path-excludes-pattern/)
 - [API healthcheck rules](configurable-rules/api-health/)
+- [JSON Schema strict strings](configurable-rules/json-schema-strict-strings/)
 
 ### Custom plugins
 

--- a/configurable-rules/json-schema-strict-strings/README.md
+++ b/configurable-rules/json-schema-strict-strings/README.md
@@ -1,0 +1,66 @@
+# JSON Schema strict strings
+
+Authors:
+- [`adamaltman`](https://github.com/adamaltman) Adam Altman (Redocly)
+ 
+## What this does and why
+
+This requires `minLength` and `maxLength` properties set on a `string` where `enum` isn't defined.
+
+## Code
+
+The first rule checks that a string uses the `minLength` and `maxLength` keywords unless an `enum` is defined.
+```yaml
+  rule/json-schema-string-has-min-and-max-length:
+    subject: 
+      type: Schema
+    where: 
+      - subject: 
+          type: Schema
+          property: type
+        assertions:  
+          const: string
+      - subject: 
+          type: Schema
+          property: enum
+        assertions: 
+          defined: false        
+    assertions: 
+      required: 
+        - minLength
+        - maxLength
+```
+
+## Examples
+
+The following OpenAPI has schemas prefixed with either `Good` or `Bad` to show the configurable rules catch the likely bad uses of keywords.
+
+```yaml
+openapi: 3.1.0
+info: 
+  title: Unintended schema misconfigurations
+  version: 1.0.0
+paths: {}
+components: 
+  schemas: 
+
+    BadString:
+      type: string
+
+    GoodStringBecauseEnum:
+      type: string
+      enum:
+        - ABC
+        - DEF
+        - GHI
+        
+    GoodStringBecauseMinAndMaxLength:
+      type: string
+      minLength: 1
+      maxLength: 64
+```
+
+
+## References
+
+Inspired by a question from Keith F. 

--- a/configurable-rules/json-schema-strict-strings/openapi.yaml
+++ b/configurable-rules/json-schema-strict-strings/openapi.yaml
@@ -1,0 +1,22 @@
+openapi: 3.1.0
+info: 
+  title: Unintended schema misconfigurations
+  version: 1.0.0
+paths: {}
+components: 
+  schemas: 
+
+    BadString:
+      type: string
+
+    GoodStringBecauseEnum:
+      type: string
+      enum:
+        - ABC
+        - DEF
+        - GHI
+        
+    GoodStringBecauseMinAndMaxLength:
+      type: string
+      minLength: 1
+      maxLength: 64

--- a/configurable-rules/json-schema-strict-strings/redocly.yaml
+++ b/configurable-rules/json-schema-strict-strings/redocly.yaml
@@ -1,0 +1,19 @@
+rules:
+  rule/json-schema-string-has-min-and-max-length:
+    subject: 
+      type: Schema
+    where: 
+      - subject: 
+          type: Schema
+          property: type
+        assertions:  
+          const: string
+      - subject: 
+          type: Schema
+          property: enum
+        assertions: 
+          defined: false        
+    assertions: 
+      required: 
+        - minLength
+        - maxLength


### PR DESCRIPTION
I need help with this rule because it doesn't work as expected.

To execute the rule I need the same object in two where clauses, and our documentation is unclear if this is allowed or not. 

```
    where: 
      - subject: 
          type: Schema
          property: type
        assertions:  
          const: string
      - subject: 
          type: Schema
          property: enum
        assertions: 
          defined: false        
```
> The where object is part of a where list which must be defined in order from the root node. Nodes may be skipped in between the subject node types of the where list and those defined in the root subject type.

https://redocly.com/docs/cli/rules/configurable-rules/#where-object

It doesn't state if you can use the same node twice. If I can't, how do I accomplish this rule?