### PR TITLE
Add Azure APIM unsupported keyword configurable rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The [custom plugin](https://redocly.com/docs/cli/custom-plugins/) is the ultimat
 - [OpenAI isConsequential](./custom-plugin-decorators/openai-is-consequential) - add `x-openai-isConsequential: true` specification extension to GET operations.
 - [Remove extensions](./custom-plugin-decorators/remove-extensions) - remove any given [OpenAPI Extensions](https://spec.openapis.org/oas/v3.1.0#specification-extensions) from an OpenAPI document.
 - [Remove unused tags](./custom-plugin-decorators/remove-unused-tags) - remove tags that are declared but not used by any operations.
+- [Azure APIM](./custom-plugin-decorators/azure-apim) - remove features unsupported by Azure APIM such as examples.
 
 #### Rules (for custom plugins)
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ There are some fantastic examples of [configurable rules](https://redocly.com/do
 - [API healthcheck rules](configurable-rules/api-health/)
 - [String schemas length defined](configurable-rules/string-schemas-length-defined/)
 - [JSON Schema misconfigurations](configurable-rules/json-schema-misconfigurations/)
+- [Azure APIM unsupported keywords](configurable-rules/azure-apim-unsupported-keyword/)
 
 ### Custom plugins
 

--- a/configurable-rules/azure-apim-unsupported-keyword/README.md
+++ b/configurable-rules/azure-apim-unsupported-keyword/README.md
@@ -1,0 +1,193 @@
+# Azure APIM support
+
+Authors:
+- [`adamaltman`](https://github.com/adamaltman) Adam Altman (Redocly)
+ 
+## What this does and why
+
+This catches OpenAPI usage unsupported or ignored by [Azure API Management](https://learn.microsoft.com/en-us/azure/api-management/api-management-api-import-restrictions):
+- `operationId` must be kebab-case and 76 characters max length.
+- Operation `summary` must be 300 characters max length.
+- Security is ignored.
+- Only one server is used.
+- `$ref` must be used for schemas and must only point to in-file components schemas (no external files or URLs).
+- A [table full of unsupported properties](https://learn.microsoft.com/en-us/azure/api-management/api-management-api-import-restrictions#unsupported) are flagged as errors.
+
+Note that a lot of the usage contradicts best practices. As such, it might be more prudent to use a decorator to transform a richer OpenAPI description into one that is supported by Azure APIM as a step in a pipeline.
+
+This ruleset can help validate the output of the decorator is viable for Azure APIM.
+
+Azure APIM isn't prescriptive if unsupported features break the import/add/update process or if they are silently ignored.
+Users have a reported a combination of those behaviors.
+
+## Code
+
+The first rule checks that the `operationId` conforms to the Azure APIM expectations of kebab-case and 76 max characters.
+It is set to be a warning level severity because Azure APIM automatically transforms non-compliant `operationId` values.
+
+```yaml
+rules:
+  rule/operation-pattern-azure-apim:
+    subject: 
+      type: Operation
+      property: operationId
+    assertions: 
+      casing: kebab-case
+      maxLength: 76
+    severity: warn
+```
+
+The second rule checks that the operation `summary` is 300 characters max length.
+```yaml
+  rule/summary-length-azure-apim:
+    subject: 
+      type: Operation
+      property: summary
+    assertions: 
+      maxLength: 300
+    severity: warn
+```
+
+The next rules highlights if there would be any servers that are ignored (and if you have any that don't use HTTPS):
+
+```yaml
+  rule/multiple-servers-ignored-azure-apim:
+    subject: 
+      type: ServerList
+    assertions: 
+      maxLength: 1
+    message: If multiple servers are specified, API Management will use the first HTTPS URL it finds.
+    severity: warn
+  
+  rule/servers-not-https-azure-apim:
+    subject: 
+      type: Server
+      property: url
+    assertions: 
+      pattern: '^https:\/\/.*'
+    message: Server URL must start with HTTPS.
+```
+
+The next rule checks that schema is not defined inline (uses a `$ref` for MediaType `schema`).
+It also checks that the reference object link is to the components section of the same file which means it starts with `#/components`. 
+
+```yaml
+  rule/mediatype-schema-ref-pattern-azure-apim:
+    subject: 
+      type: MediaType
+      property: schema
+    message: Inline schema definitions and refs that point to URLs or files aren't supported.
+    assertions:     
+      ref: /^#\/components\/.*/
+```
+
+The next two rules ensure external docs and info summary aren't used.
+
+```yaml
+  rule/external-docs-unsupported-azure-apim:
+    subject: 
+      type: ExternalDocs
+    assertions: 
+      defined: false
+    message: Azure APIM does not support externalDocs.
+  
+  rule/info-summary-unsupported-azure-apim:
+    subject: 
+      type: Info
+      property: summary
+    assertions: 
+      defined: false
+    message: Azure APIM does not Info summary.
+```
+
+APIM ignores security. This rule let's you know if it is left in there:
+
+```yaml
+  rule/security-ignored-azure-apim:
+    subject: 
+      type: SecurityRequirementList
+    assertions: 
+      defined: false
+    message: Azure APIM ignores security.
+```
+
+APIM documentation has a table of unsupported OpenAPI keywords. The following set of rules makes sure those features aren't used.
+
+```yaml
+  rule/components-unsupported-azure-apim:
+    subject: 
+      type: Components
+    assertions: 
+      disallowed: 
+        - responses
+        - parameters
+        - examples
+        - requestBodies
+        - headers
+        - securitySchemes
+        - links
+        - callbacks
+    message: Azure APIM does not support components other than schemas.
+      
+  rule/trace-unsupported-azure-apim:
+    subject: 
+      type: PathItem
+    assertions: 
+      disallowed: 
+        - trace
+    message: Azure APIM does not support trace operations.
+
+  rule/path-item-servers-unsupported-azure-apim:
+    subject: 
+      type: PathItem
+    assertions: 
+      disallowed: 
+        - servers
+    message: Azure APIM does not support servers defined on path items.
+
+  rule/operation-properties-unsupported-azure-apim:
+    subject: 
+      type: Operation
+    assertions: 
+      disallowed: 
+        - externalDocs
+        - callbacks
+        - servers
+        - security
+
+  rule/parameter-properties-unsupported-azure-apim:
+    subject: 
+      type: Parameter
+    assertions: 
+      disallowed: 
+        - allowEmptyValue
+        - style
+        - explode
+        - allowReserved
+```
+
+## Examples
+
+The following OpenAPI has schemas prefixed with either `Allowed` or `Unsupported` to show the configurable rules catch the likely bad uses of keywords.
+
+### Unsupported externalDocs
+
+```yaml
+openapi: 3.1.0
+externalDocs: https://example.com
+# ...
+```
+
+Remove `externalDocs` to avoid any issues.
+
+**Allowed transformation**
+```yaml
+openapi: 3.1.0
+# ...
+```
+
+The [example OpenAPI description](./openapi.yaml) has a variety of unsupported features in use.
+
+## References
+
+- https://learn.microsoft.com/en-us/azure/api-management/api-management-api-import-restrictions

--- a/configurable-rules/azure-apim-unsupported-keyword/README.md
+++ b/configurable-rules/azure-apim-unsupported-keyword/README.md
@@ -97,7 +97,7 @@ The next two rules ensure external docs and info summary aren't used.
       property: summary
     assertions: 
       defined: false
-    message: Azure APIM does not Info summary.
+    message: Azure APIM does not support Info summary.
 ```
 
 APIM ignores security. This rule let's you know if it is left in there:

--- a/configurable-rules/azure-apim-unsupported-keyword/openapi.yaml
+++ b/configurable-rules/azure-apim-unsupported-keyword/openapi.yaml
@@ -7,7 +7,7 @@ info:
   summary: Azure APIM test
   version: 1.0.0
   
-security: []
+security: [] # violates rule/security-ignored-azure-apim, should not be defined
 servers: 
   - url: https://foo.bar
   - url: baz.qux 

--- a/configurable-rules/azure-apim-unsupported-keyword/openapi.yaml
+++ b/configurable-rules/azure-apim-unsupported-keyword/openapi.yaml
@@ -1,0 +1,89 @@
+openapi: 3.1.0
+externalDocs: 
+  url: example.com
+  
+info: 
+  title: Azure APIM test case.
+  summary: Azure APIM test
+  version: 1.0.0
+  
+security: []
+servers: 
+  - url: https://foo.bar
+  - url: baz.qux 
+paths:
+  /trucks:
+    post: 
+      operationId: create-trucks
+      summary: Create a truck
+      requestBody: 
+        content:
+          application/json:
+            schema: 
+              $ref: "#/components/schemas/Truck"
+      responses: 
+        '201':
+          description: CREATED
+          content:
+            application/json:
+              schema: 
+                $ref: "#/components/schemas/Truck"
+    get: 
+      operationId: get-trucks
+      summary: List trucks
+      externalDocs: 
+        url: example.com
+        
+      requestBody: 
+        content:
+          application/json:
+            schema: 
+              $ref: "#/components/schemas/Truck"
+      responses: 
+        '200':
+          description: OK
+          content:
+            application/json:
+              # invalid because not using ref for the whole schema.
+              schema: 
+                type: array
+                items:
+                  - $ref: "#/components/schemas/Truck"
+
+  /scooters:
+    post: 
+      operationId: create-scooters
+      summary: Create a scooter
+      requestBody: 
+        content:
+          application/json:
+            schema: 
+              type: object
+              properties:
+                name:
+                  type: string
+      responses: 
+        '200':
+          description: OK
+          content: 
+            application/json:
+              type: object
+              properties:
+                name:
+                  type: string
+
+components: 
+  schemas: 
+    Truck:
+      type: object
+      properties:
+        weight:
+          type: number
+        length:
+          type: number
+        make:
+          type: string
+        model:
+          type: string
+        year:
+          type: number

--- a/configurable-rules/azure-apim-unsupported-keyword/redocly.yaml
+++ b/configurable-rules/azure-apim-unsupported-keyword/redocly.yaml
@@ -1,0 +1,113 @@
+rules:
+  rule/operation-pattern-azure-apim:
+    subject: 
+      type: Operation
+      property: operationId
+    assertions: 
+      casing: kebab-case
+      maxLength: 76
+    severity: warn
+  rule/summary-length-azure-apim:
+    subject: 
+      type: Operation
+      property: summary
+    assertions: 
+      maxLength: 300
+    severity: warn
+
+  rule/multiple-servers-ignored-azure-apim:
+    subject: 
+      type: ServerList
+    assertions: 
+      maxLength: 1
+    message: If multiple servers are specified, API Management will use the first HTTPS URL it finds.
+    severity: warn
+
+  rule/servers-not-https-azure-apim:
+    subject: 
+      type: Server
+      property: url
+    assertions: 
+      pattern: '^https:\/\/.*'
+    message: Server URL must start with HTTPS.
+
+  rule/mediatype-schema-ref-pattern-azure-apim:
+    subject: 
+      type: MediaType
+      property: schema
+    message: Inline schema definitions and refs that point to URLs or files aren't supported.
+    assertions:     
+      ref: /^#\/components\/.*/
+
+  rule/external-docs-unsupported-azure-apim:
+    subject: 
+      type: ExternalDocs
+    assertions: 
+      defined: false
+    message: Azure APIM does not support externalDocs.
+  
+  rule/info-summary-unsupported-azure-apim:
+    subject: 
+      type: Info
+      property: summary
+    assertions: 
+      defined: false
+    message: Azure APIM does not Info summary.
+
+  rule/security-ignored-azure-apim:
+    subject: 
+      type: SecurityRequirementList
+    assertions: 
+      defined: false
+    message: Azure APIM ignores security.
+    
+  rule/components-unsupported-azure-apim:
+    subject: 
+      type: Components
+    assertions: 
+      disallowed: 
+        - responses
+        - parameters
+        - examples
+        - requestBodies
+        - headers
+        - securitySchemes
+        - links
+        - callbacks
+    message: Azure APIM does not support components other than schemas.
+      
+  rule/trace-unsupported-azure-apim:
+    subject: 
+      type: PathItem
+    assertions: 
+      disallowed: 
+        - trace
+    message: Azure APIM does not support trace operations.
+
+  rule/path-item-servers-unsupported-azure-apim:
+    subject: 
+      type: PathItem
+    assertions: 
+      disallowed: 
+        - servers
+    message: Azure APIM does not support servers defined on path items.
+
+  rule/operation-properties-unsupported-azure-apim:
+    subject: 
+      type: Operation
+    assertions: 
+      disallowed: 
+        - externalDocs
+        - callbacks
+        - servers
+        - security
+
+  rule/parameter-properties-unsupported-azure-apim:
+    subject: 
+      type: Parameter
+    assertions: 
+      disallowed: 
+        - allowEmptyValue
+        - style
+        - explode
+        - allowReserved

--- a/custom-plugin-decorators/azure-apim/README.md
+++ b/custom-plugin-decorators/azure-apim/README.md
@@ -1,0 +1,136 @@
+# Azure APIM decorator
+
+Authors:
+
+- [`@adamaltman`](https://github.com/adamaltman), Adam Altman (Redocly)
+
+## What this does and why
+
+[Azure APIM](https://learn.microsoft.com/en-us/azure/api-management/api-management-api-import-restrictions) doesn't support a variety of OpenAPI features (one of which is examples).
+Examples causes an error when attempting to import OpenAPI descriptions that contain examples to Azure APIM.
+
+This decorator removes examples from schemas, media types, and components.
+
+This is a decorator you can run in a pipeline to transform your OpenAPI description prior to uploading to Azure APIM.
+Note that Azure APIM has many restrictions, and it might require more transformation prior to uploading to Azure APIM.
+
+You certainly would want to have the examples for purposes of documentation. Redocly renders multiple media type examples beautifully.
+
+Contribute to this community cookbook by adding decorators for issues you find with your imports to Azure APIM.
+
+## Code
+
+The code is entirely in `azure-apim.js`:
+
+```javascript
+module.exports = {
+    id: "azure-apim",
+    decorators: {
+      oas3: {
+        "remove-examples": RemoveExamples,
+      },
+    },
+  };
+  
+  /** @type {import('@redocly/cli').OasDecorator} */
+  function RemoveExamples() {
+    return {
+      Schema: {
+        leave(Schema) {
+          if (Schema['examples']) {
+            delete Schema['examples'];
+          }
+        }
+      },
+      MediaType: {
+        leave(MediaType) {
+            if (MediaType['examples']) {
+                delete MediaType['examples'];
+            }
+        }
+      },
+      Components: {
+        leave(Components) {
+          if (Components['examples']) {
+            delete Components['examples'];
+          }
+        }
+      }
+    }
+  };
+
+```
+
+The code sets the plugin name to `azure-apim` and adds a decorator named `remove-examples`.
+
+It operates on the `Schemas`, `MediaType`, and `Components` element (in OpenAPI 3.x descriptions) to remove the `examples` node.
+
+## Examples
+
+Add the plugin to `redocly.yaml` and enable the decorator:
+
+```yaml
+plugins:
+  - ./azure-apim.js
+
+decorators:
+  azure-apim/remove-examples: on
+```
+
+Here is an example of an operation before and after:
+
+**Before**:
+
+```yaml
+/fees:
+  get:
+    summary: List fees
+    operationId: GetFees
+    description: Retrieves collection of fees.
+    responses:
+      "200":
+        description: Fees retrieved.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Fees"
+            examples:
+              regular-fee:
+                $ref: "#/components/examples/RegularFee"
+      "401":
+        $ref: "#/components/responses/Unauthorized"
+      "403":
+        $ref: "#/components/responses/Forbidden"
+      "404":
+        $ref: "#/components/responses/NotFound"
+```
+
+**After**:
+
+```yaml
+/fees:
+  get:
+    summary: List fees
+    operationId: GetFees
+    description: Retrieves collection of fees.
+    responses:
+      "200":
+        description: Fees retrieved.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Fees"
+      "401":
+        $ref: "#/components/responses/Unauthorized"
+      "403":
+        $ref: "#/components/responses/Forbidden"
+      "404":
+        $ref: "#/components/responses/NotFound"
+```
+
+🎉 Notice `examples` is removed from the `application/json` media type.
+
+## References
+
+- https://learn.microsoft.com/en-us/azure/api-management/api-management-api-import-restrictions
+- OpenAPI [node types](https://redocly.com/docs/openapi-visual-reference/openapi-node-types/)

--- a/custom-plugin-decorators/azure-apim/README.md
+++ b/custom-plugin-decorators/azure-apim/README.md
@@ -20,46 +20,8 @@ Contribute to this community cookbook by adding decorators for issues you find w
 
 ## Code
 
-The code is entirely in `azure-apim.js`:
+The code is entirely in [azure-apim.js](./azure-apim.js).
 
-```javascript
-module.exports = {
-    id: "azure-apim",
-    decorators: {
-      oas3: {
-        "remove-examples": RemoveExamples,
-      },
-    },
-  };
-  
-  /** @type {import('@redocly/cli').OasDecorator} */
-  function RemoveExamples() {
-    return {
-      Schema: {
-        leave(Schema) {
-          if (Schema['examples']) {
-            delete Schema['examples'];
-          }
-        }
-      },
-      MediaType: {
-        leave(MediaType) {
-            if (MediaType['examples']) {
-                delete MediaType['examples'];
-            }
-        }
-      },
-      Components: {
-        leave(Components) {
-          if (Components['examples']) {
-            delete Components['examples'];
-          }
-        }
-      }
-    }
-  };
-
-```
 
 The code sets the plugin name to `azure-apim` and adds a decorator named `remove-examples`.
 

--- a/custom-plugin-decorators/azure-apim/azure-apim.js
+++ b/custom-plugin-decorators/azure-apim/azure-apim.js
@@ -1,0 +1,35 @@
+module.exports = {
+  id: "azure-apim",
+  decorators: {
+    oas3: {
+      "remove-examples": RemoveExamples,
+    },
+  },
+};
+
+/** @type {import('@redocly/cli').OasDecorator} */
+function RemoveExamples() {
+  return {
+    Schema: {
+      leave(Schema) {
+        if (Schema['examples']) {
+          delete Schema['examples'];
+        }
+      }
+    },
+    MediaType: {
+      leave(MediaType) {
+          if (MediaType['examples']) {
+              delete MediaType['examples'];
+          }
+      }
+    },
+    Components: {
+      leave(Components) {
+        if (Components['examples']) {
+          delete Components['examples'];
+        }
+      }
+    }
+  }
+};


### PR DESCRIPTION
Some people want their OpenAPI descriptions to be compatible with Azure APIM. This helps enforce that. 

This could be particularly helpful as a first step towards writing a decorator to transform a more rich description into one that uses only the features Azure APIM supports.