### PR TITLE
fix: update tag-sorting plugin to use new plugin syntax

### DIFF
--- a/custom-plugin-decorators/tag-sorting/README.md
+++ b/custom-plugin-decorators/tag-sorting/README.md
@@ -17,11 +17,13 @@ Here's the main plugin entrypoint, it's in `tag-sorting.js`:
 
 const SortTagsAlphabetically = require('./decorator-alpha');
 
-module.exports = {
-  id: 'tag-sorting',
-  decorators: {
-    oas3: {
-      'alphabetical': SortTagsAlphabetically,
+module.exports = function tagSortingPlugin() {
+  return {
+    id: 'tag-sorting',
+    decorators: {
+      oas3: {
+        'alphabetical': SortTagsAlphabetically,
+      }
     }
   }
 }

--- a/custom-plugin-decorators/tag-sorting/tag-sorting.js
+++ b/custom-plugin-decorators/tag-sorting/tag-sorting.js
@@ -1,11 +1,12 @@
 const SortTagsAlphabetically = require('./decorator-alpha');
 
-module.exports = {
-  id: 'tag-sorting',
-  decorators: {
-    oas3: {
-      'alphabetical': SortTagsAlphabetically,
+module.exports = function tagSortingPlugin() {
+  return {
+    id: 'tag-sorting',
+    decorators: {
+      oas3: {
+        'alphabetical': SortTagsAlphabetically,
+      }
     }
   }
-	
 }


### PR DESCRIPTION
We changed our plugin syntax, update one of the cookbook entries to use the updated syntax.