### PR TITLE
update examples according to changes in Redocly CLI v2

### DIFF
--- a/custom-plugin-decorators/azure-apim/azure-apim.js
+++ b/custom-plugin-decorators/azure-apim/azure-apim.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default function plugin() {
   id: "azure-apim",
   decorators: {
     oas3: {

--- a/custom-plugin-decorators/openai-is-consequential/README.md
+++ b/custom-plugin-decorators/openai-is-consequential/README.md
@@ -19,7 +19,7 @@ If you want to set the GET operations to true too, then this decorator is for yo
 The code is entirely in `openai-is-consequential.js`:
 
 ```javascript
-module.exports = {
+export default function plugin() {
   id: "openai-plugin",
   decorators: {
     oas3: {

--- a/custom-plugin-decorators/openai-is-consequential/openai-is-consequential.js
+++ b/custom-plugin-decorators/openai-is-consequential/openai-is-consequential.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default function plugin() {
   id: "openai-plugin",
   decorators: {
     oas3: {

--- a/custom-plugin-decorators/remove-extensions/README.md
+++ b/custom-plugin-decorators/remove-extensions/README.md
@@ -17,8 +17,7 @@ The plugin itself can be found in [`remove-extensions.js'](./remove-extensions.j
 Create a `plugin.js` file to refer to this file:
 
 ```js
-const RemoveExtensions = require("./remove-extensions");
-const id = "plugin";
+import RemoveExtensions from "./remove-extensions";
 
 /** @type {import('@redocly/cli').DecoratorsConfig} */
 const decorators = {
@@ -27,10 +26,12 @@ const decorators = {
   },
 };
 
-module.exports = {
-  id,
-  decorators,
-};
+export default function plugin() {
+  return {
+    id: "plugin",
+    decorators,
+  };
+}
 ```
 
 Create/edit `redocly.yaml` as follows (edit with your own settings):
@@ -47,7 +48,7 @@ apis:
           - x-amazon*
           - x-google*
 plugins:
-  - "./plugin.js"
+  - ./plugin.js
 ```
 
 Run the `bundle` command to remove all the [GCP](https://cloud.google.com/endpoints/docs/openapi/openapi-extensions) and [AWS](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions.html) custom OpenAPI extensions from the OpenAPI description:
@@ -55,6 +56,7 @@ Run the `bundle` command to remove all the [GCP](https://cloud.google.com/endpoi
 ```bash
 redocly bundle with-plugin@latest --output dist/with-plugin.yaml
 ```
+
 The `extensions` parameter is optional. If empty or not set, it will remove all extensions (elements starting with `x-`). The accepted values for the `extensions` param are:
 
 - `extensions: <regex-valid-extension>`
@@ -62,7 +64,6 @@ The `extensions` parameter is optional. If empty or not set, it will remove all 
 - `extensions: <empty>`
 
 Regular expressions follow [Javascript Regex convention](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions).
-
 
 ## Examples
 

--- a/custom-plugin-decorators/remove-extensions/remove-extensions.js
+++ b/custom-plugin-decorators/remove-extensions/remove-extensions.js
@@ -1,5 +1,3 @@
-module.exports = RemoveExtensions;
-
 /** @type {import('@redocly/cli').OasDecorator} */
 
 const openAPIExtensions = /x-*/;
@@ -8,57 +6,76 @@ const openAPIExtensions = /x-*/;
 // message is str
 // bool is boolean
 function assert(bool, message) {
-	if (!bool) {
-		const err = message !== undefined ? new Error(message) : new Error("an error occured")
-		throw err
-	}
+  if (!bool) {
+    const err =
+      message !== undefined
+        ? new Error(message)
+        : new Error("an error occured");
+    throw err;
+  }
 }
 
 function doRemoveParamFromNode(node, param) {
-	assert(typeof param === 'string', "extension must be a string")
-	assert(isExtensionValid(param), `[Aborting] String "${param}" is not a valid OpenAPI extension, it must begin with "x-"`)
-	delete node[param]
-	console.log('Deleteted extension "%s" from object "%O"', param, node)
+  assert(typeof param === "string", "extension must be a string");
+  assert(
+    isExtensionValid(param),
+    `[Aborting] String "${param}" is not a valid OpenAPI extension, it must begin with "x-"`
+  );
+  delete node[param];
+  console.log('Deleteted extension "%s" from object "%O"', param, node);
 }
 
 function isExtensionValid(extension) {
-	assert(typeof extension === 'string', "extension must be a string")
-	if (extension.match(openAPIExtensions)) {
-		return true
-	} else {
-		return false
-	}
+  assert(typeof extension === "string", "extension must be a string");
+  if (extension.match(openAPIExtensions)) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
 function removeExtensionsFromNode(node, extensions) {
-	const extensionsType = typeof extensions
-	assert(extensionsType === undefined || extensionsType === 'string' || extensionsType === 'object', `Extensions must be a string or a list of string instead of being of type "${extensionsType}"`)
-	if (extensions === undefined || extensions === null || extensions === {} || extensions === '') {
-		console.log('Deleting all OpenAPI extensions (params starting with "x-")...')
-		Object.keys(node).filter(param => param.match(openAPIExtensions)).forEach((param) => {
-			doRemoveParamFromNode(node, param)
-		})
-	} else if (extensionsType === 'string') {
-		// extensions is a string representing a regex - delete all the params that match this regex
-		Object.keys(node).filter(param => param.match(extensions)).forEach((param) => {
-			doRemoveParamFromNode(node, param)
-		})
-	} else {
-		// extensions a list
-		// only return something if all strings are valid OpenAPI spec, otherwise panic (handled by the assert)
-		extensions.forEach((extension) => {
-			// extension is a string representing a regex - delete all the params that match this regex
-			Object.keys(node).filter(param => param.match(extension)).forEach((param) => {
-				doRemoveParamFromNode(node, param)
-			})
-		})
-	}
+  const extensionsType = typeof extensions;
+  assert(
+    extensionsType === undefined ||
+      extensionsType === "string" ||
+      extensionsType === "object",
+    `Extensions must be a string or a list of string instead of being of type "${extensionsType}"`
+  );
+  if (extensions === undefined || extensions === null || extensions === "") {
+    console.log(
+      'Deleting all OpenAPI extensions (params starting with "x-")...'
+    );
+    Object.keys(node)
+      .filter((param) => param.match(openAPIExtensions))
+      .forEach((param) => {
+        doRemoveParamFromNode(node, param);
+      });
+  } else if (extensionsType === "string") {
+    // extensions is a string representing a regex - delete all the params that match this regex
+    Object.keys(node)
+      .filter((param) => param.match(extensions))
+      .forEach((param) => {
+        doRemoveParamFromNode(node, param);
+      });
+  } else {
+    // extensions a list
+    // only return something if all strings are valid OpenAPI spec, otherwise panic (handled by the assert)
+    extensions.forEach((extension) => {
+      // extension is a string representing a regex - delete all the params that match this regex
+      Object.keys(node)
+        .filter((param) => param.match(extension))
+        .forEach((param) => {
+          doRemoveParamFromNode(node, param);
+        });
+    });
+  }
 }
 
-function RemoveExtensions({extensions}) {
-	return {
-		any: {
-			enter: (node, _ctx) => removeExtensionsFromNode(node, extensions),
-		}
-	}
-};
+export default function RemoveExtensions({ extensions }) {
+  return {
+    any: {
+      enter: (node, _ctx) => removeExtensionsFromNode(node, extensions),
+    },
+  };
+}

--- a/custom-plugin-decorators/remove-unused-tags/README.md
+++ b/custom-plugin-decorators/remove-unused-tags/README.md
@@ -60,7 +60,7 @@ To use the custom decorator, add configuration like the following to the `redocl
 
 ```yaml
 plugins:
-  - "./tags.js"
+  - ./tags.js
 
 decorators:
   tags/no-unused-tags: on
@@ -70,7 +70,7 @@ If there are tags that should be preserved even though they are unused, add them
 
 ```yaml
 plugins:
-  - "./tags.js"
+  - ./tags.js
 
 decorators:
   tags/no-unused-tags:

--- a/custom-plugin-decorators/remove-unused-tags/README.md
+++ b/custom-plugin-decorators/remove-unused-tags/README.md
@@ -1,8 +1,8 @@
 # Remove unused tags
 
 Authors:
+
 - [`@lornajane`](https://github.com/lornajane), Lorna Mitchell (Redocly)
- 
 
 ## What this does and why
 
@@ -17,7 +17,7 @@ This is a useful decorator to use when you are reducing a larger OpenAPI file fo
 The plugin code itself is in `tags.js`:
 
 ```js
-module.exports = {
+export default function plugin() {
   id: "tags",
   decorators: {
     oas3: {
@@ -60,7 +60,7 @@ To use the custom decorator, add configuration like the following to the `redocl
 
 ```yaml
 plugins:
-  - './tags.js'
+  - "./tags.js"
 
 decorators:
   tags/no-unused-tags: on
@@ -70,7 +70,7 @@ If there are tags that should be preserved even though they are unused, add them
 
 ```yaml
 plugins:
-  - './tags.js'
+  - "./tags.js"
 
 decorators:
   tags/no-unused-tags:
@@ -95,7 +95,7 @@ Start by adding the decorator to `redocly.yaml` and including some ignore settin
 
 ```yaml
 plugins:
-  - './tags.js'
+  - ./tags.js
 
 decorators:
   tags/no-unused-tags:

--- a/custom-plugin-decorators/remove-unused-tags/tags.js
+++ b/custom-plugin-decorators/remove-unused-tags/tags.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default function plugin() {
   id: "tags",
   decorators: {
     oas3: {

--- a/custom-plugin-decorators/swap-summary-description/README.md
+++ b/custom-plugin-decorators/swap-summary-description/README.md
@@ -1,15 +1,16 @@
 # Swap the summary and description fields
 
 Authors:
+
 - [`@lornajane`](https://github.com/lornajane), Lorna Mitchell (Redocly)
- 
+
 ## What this does and why
 
 We sometimes see API descriptions with the fields mixed up.
 The most common of these is the `summary` and `description` fields on Operations in OpenAPI, some generators seem to produce the fields with the content reversed.
 
-* Summary: used when the operations are displayed in a list, it should be a very short phrase to describe the operation.
-* Description: used to supply more detail, used when the operation is displayed in detail. The description field also suports Markdown.
+- Summary: used when the operations are displayed in a list, it should be a very short phrase to describe the operation.
+- Description: used to supply more detail, used when the operation is displayed in detail. The description field also suports Markdown.
 
 This decorator takes the content of both fields and (as long as there is some content in the description field), swaps them over.
 
@@ -18,7 +19,7 @@ This decorator takes the content of both fields and (as long as there is some co
 The following code snippet shows the decorator, in a file named `swap-fields.js`:
 
 ```js
-module.exports = {
+export default function plugin() {
   id: "swap-fields",
   decorators: {
     oas3: {
@@ -96,8 +97,9 @@ webhooks:
             schema:
               "$ref": "#/components/schemas/webhook-branch-protection-configuration-disabled"
       responses:
-        '200':
-          description: Return a 200 status to indicate that the data was received
+        "200":
+          description:
+            Return a 200 status to indicate that the data was received
             successfully
 
 components:
@@ -109,7 +111,7 @@ components:
         action:
           type: string
           enum:
-          - disabled
+            - disabled
 ```
 
 After the decorator has been run, the updated file looks like the following example:
@@ -143,9 +145,9 @@ webhooks:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/webhook-branch-protection-configuration-disabled'
+              $ref: "#/components/schemas/webhook-branch-protection-configuration-disabled"
       responses:
-        '200':
+        "200":
           description: Return a 200 status to indicate that the data was received successfully
 components:
   schemas:

--- a/custom-plugin-decorators/swap-summary-description/README.md
+++ b/custom-plugin-decorators/swap-summary-description/README.md
@@ -20,34 +20,36 @@ The following code snippet shows the decorator, in a file named `swap-fields.js`
 
 ```js
 export default function plugin() {
-  id: "swap-fields",
-  decorators: {
-    oas3: {
-      "summary-description": () => {
-        return {
-          Operation: {
-            leave(target) {
-              let description = "";
-              let summary = "";
-              if (target.description) {
-                description = target.description
-              }
-              if (target.summary) {
-                summary = target.summary
-              }
+  return {
+    id: "swap-fields",
+    decorators: {
+      oas3: {
+        "summary-description": () => {
+          return {
+            Operation: {
+              leave(target) {
+                let description = "";
+                let summary = "";
+                if (target.description) {
+                  description = target.description;
+                }
+                if (target.summary) {
+                  summary = target.summary;
+                }
 
-              // only swap them if there is some description content
-              if(description.length > 0){
-                target.description = summary;
-                target.summary = description;
-              }
+                // only swap them if there is some description content
+                if (description.length > 0) {
+                  target.description = summary;
+                  target.summary = description;
+                }
+              },
             },
-          },
-        };
+          };
+        },
       },
     },
-  },
-};
+  };
+}
 ```
 
 Put this file alongside your `redocly.yaml` file, and add the following configuration to `redocly.yaml`:
@@ -98,9 +100,7 @@ webhooks:
               "$ref": "#/components/schemas/webhook-branch-protection-configuration-disabled"
       responses:
         "200":
-          description:
-            Return a 200 status to indicate that the data was received
-            successfully
+          description: Return a 200 status to indicate that the data was received successfully
 
 components:
   schemas:

--- a/custom-plugin-decorators/swap-summary-description/swap-fields.js
+++ b/custom-plugin-decorators/swap-summary-description/swap-fields.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default function plugin() {
   id: "swap-fields",
   decorators: {
     oas3: {

--- a/custom-plugin-decorators/swap-summary-description/swap-fields.js
+++ b/custom-plugin-decorators/swap-summary-description/swap-fields.js
@@ -1,29 +1,31 @@
 export default function plugin() {
-  id: "swap-fields",
-  decorators: {
-    oas3: {
-      "summary-description": () => {
-        return {
-          Operation: {
-            leave(target) {
-              let description = "";
-              let summary = "";
-              if (target.description) {
-                description = target.description
-              }
-              if (target.summary) {
-                summary = target.summary
-              }
+  return {
+    id: "swap-fields",
+    decorators: {
+      oas3: {
+        "summary-description": () => {
+          return {
+            Operation: {
+              leave(target) {
+                let description = "";
+                let summary = "";
+                if (target.description) {
+                  description = target.description;
+                }
+                if (target.summary) {
+                  summary = target.summary;
+                }
 
-              // only swap them if there is some description content
-              if(description.length > 0){
-                target.description = summary;
-                target.summary = description;
-              }
+                // only swap them if there is some description content
+                if (description.length > 0) {
+                  target.description = summary;
+                  target.summary = description;
+                }
+              },
             },
-          },
-        };
+          };
+        },
       },
     },
-  },
-};
+  };
+}

--- a/custom-plugin-decorators/tag-sorting/README.md
+++ b/custom-plugin-decorators/tag-sorting/README.md
@@ -1,8 +1,9 @@
 # Decorator to sort tags in an API description
 
 Authors:
+
 - [`@lornajane`](https://github.com/lornajane), Lorna Mitchell (Redocly)
- 
+
 ## What this does and why
 
 Redocly CLI has the [`tags-alphabetical`](https://redocly.com/docs/cli/rules/tags-alphabetical/) rule to error if the `tags` section isn't in alphabetical order by `name`.
@@ -14,18 +15,17 @@ This decorator provides functionality to _put_ the tags in order by name, in ord
 Here's the main plugin entrypoint, it's in `tag-sorting.js`:
 
 ```javascript
+import SortTagsAlphabetically from "./decorator-alpha";
 
-const SortTagsAlphabetically = require('./decorator-alpha');
-
-module.exports = function tagSortingPlugin() {
+export default function tagSortingPlugin() {
   return {
-    id: 'tag-sorting',
+    id: "tag-sorting",
     decorators: {
       oas3: {
-        'alphabetical': SortTagsAlphabetically,
-      }
-    }
-  }
+        alphabetical: SortTagsAlphabetically,
+      },
+    },
+  };
 }
 ```
 
@@ -34,22 +34,19 @@ The code here sets the plugin name to `tag-sorting` and adds a decorator for Ope
 The functionality for the alphabetical sorting is in `decorator-alpha.js`:
 
 ```javascript
-
-module.exports = SortTagsAlphabetically;
-
-function SortTagsAlphabetically() {
+export default function SortTagsAlphabetically() {
   console.log("re-ordering tags: alphabetical");
   return {
     TagList: {
       leave(target) {
-        target.sort((a,b) => {
+        target.sort((a, b) => {
           if (a.name < b.name) {
             return -1;
           }
         });
-      }
-    }
-  }
+      },
+    },
+  };
 }
 ```
 
@@ -61,7 +58,7 @@ Add the plugin to `redocly.yaml` and enable the decorator:
 
 ```yaml
 plugins:
-  - './tag-sorting.js'
+  - ./tag-sorting.js
 
 decorators:
   tag-sorting/alphabetical: on
@@ -91,6 +88,5 @@ tags:
 
 ## References
 
-* [`tags-alphabetical' rule](https://redocly.com/docs/cli/rules/tags-alphabetical/)
-* The [`tags` types documentation](https://redocly.com/docs/openapi-visual-reference/tags/#types)
-
+- [`tags-alphabetical' rule](https://redocly.com/docs/cli/rules/tags-alphabetical/)
+- The [`tags` types documentation](https://redocly.com/docs/openapi-visual-reference/tags/#types)

--- a/custom-plugin-decorators/tag-sorting/decorator-alpha.js
+++ b/custom-plugin-decorators/tag-sorting/decorator-alpha.js
@@ -1,16 +1,14 @@
-module.exports = SortTagsAlphabetically;
-
-function SortTagsAlphabetically() {
+export default function SortTagsAlphabetically() {
   console.log("re-ordering tags: alphabetical");
   return {
     TagList: {
       leave(target) {
-        target.sort((a,b) => {
+        target.sort((a, b) => {
           if (a.name < b.name) {
             return -1;
           }
         });
-      }
-    }
-  }
+      },
+    },
+  };
 }

--- a/custom-plugin-decorators/tag-sorting/tag-sorting.js
+++ b/custom-plugin-decorators/tag-sorting/tag-sorting.js
@@ -1,4 +1,4 @@
-import SortTagsAlphabetically from "./decorator-alpha";
+import SortTagsAlphabetically from "./decorator-alpha.js";
 
 export default function tagSortingPlugin() {
   return {

--- a/custom-plugin-decorators/tag-sorting/tag-sorting.js
+++ b/custom-plugin-decorators/tag-sorting/tag-sorting.js
@@ -1,12 +1,12 @@
-const SortTagsAlphabetically = require('./decorator-alpha');
+import SortTagsAlphabetically from "./decorator-alpha";
 
-module.exports = function tagSortingPlugin() {
+export default function tagSortingPlugin() {
   return {
-    id: 'tag-sorting',
+    id: "tag-sorting",
     decorators: {
       oas3: {
-        'alphabetical': SortTagsAlphabetically,
-      }
-    }
-  }
+        alphabetical: SortTagsAlphabetically,
+      },
+    },
+  };
 }

--- a/custom-plugin-decorators/update-example-dates/README.md
+++ b/custom-plugin-decorators/update-example-dates/README.md
@@ -18,7 +18,7 @@ You can also use expressions to add a set number of days to the value, for examp
 The `dates-plugin` plugin defines the `decorator` section and the plugin `id`:
 
 ```javascript
-import updateExampleDates from "./decorator";
+import updateExampleDates from "./decorator.js";
 
 export default function plugin() {
   return {

--- a/custom-plugin-decorators/update-example-dates/README.md
+++ b/custom-plugin-decorators/update-example-dates/README.md
@@ -18,22 +18,24 @@ You can also use expressions to add a set number of days to the value, for examp
 The `dates-plugin` plugin defines the `decorator` section and the plugin `id`:
 
 ```javascript
-const updateExampleDates = require("./decorator");
+import updateExampleDates from "./decorator";
 
-module.exports = {
-  id: "dates-plugin",
-  decorators: {
-    oas3: {
-      "update-example-dates": updateExampleDates,
+export default function plugin() {
+  return {
+    id: "dates-plugin",
+    decorators: {
+      oas3: {
+        "update-example-dates": updateExampleDates,
+      },
     },
-  },
-};
+  };
+}
 ```
 
 Here's the main part of the decorator (from `decorator.js`):
 
 ```javascript
-function updateExampleDates() {
+export default function updateExampleDates() {
   return {
     // Covers the 'examples' keyword (including examples in the 'components' section)
     Example: {

--- a/custom-plugin-decorators/update-example-dates/decorator.js
+++ b/custom-plugin-decorators/update-example-dates/decorator.js
@@ -1,4 +1,4 @@
-function updateExampleDates() {
+export default function updateExampleDates() {
   return {
     // Covers the 'examples' keyword (including examples in the 'components' section)
     Example: {
@@ -48,5 +48,3 @@ function computeDateTemplate(template) {
     .reduce((sum, item) => sum + +item, 0);
   return new Date(calculated).toISOString();
 }
-
-module.exports = updateExampleDates;

--- a/custom-plugin-decorators/update-example-dates/plugin.js
+++ b/custom-plugin-decorators/update-example-dates/plugin.js
@@ -1,10 +1,12 @@
-const updateExampleDates = require("./decorator");
+import updateExampleDates from "./decorator";
 
-module.exports = {
-  id: "dates-plugin",
-  decorators: {
-    oas3: {
-      "update-example-dates": updateExampleDates,
+export default function plugin() {
+  return {
+    id: "dates-plugin",
+    decorators: {
+      oas3: {
+        "update-example-dates": updateExampleDates,
+      },
     },
-  },
-};
+  };
+}

--- a/custom-plugin-decorators/update-example-dates/plugin.js
+++ b/custom-plugin-decorators/update-example-dates/plugin.js
@@ -1,5 +1,5 @@
 import updateExampleDates from "./decorator";
-
+import updateExampleDates from "./decorator.js"
 export default function plugin() {
   return {
     id: "dates-plugin",

--- a/custom-plugin-rules/code-sample-checks/README.md
+++ b/custom-plugin-rules/code-sample-checks/README.md
@@ -1,6 +1,7 @@
 # Check code sample coverage
 
 Authors:
+
 - Laura Rubin @SansContext (with great help from Manny Silva @hawkeyexl in the Write the Docs Slack)
 
 ## What this does and why
@@ -15,13 +16,13 @@ You probably want to set these to `warn` if you think you're going to have a lot
 
 ```yaml
 rule/x-code-samples-exist:
-    subject:
-      type: Operation
-      property: x-code-samples
-    assertions:
-      defined: true
-    message: "Each path must have an x-code-samples object."
-    severity: warn
+  subject:
+    type: Operation
+    property: x-code-samples
+  assertions:
+    defined: true
+  message: "Each path must have an x-code-samples object."
+  severity: warn
 ```
 
 ## Code
@@ -32,26 +33,26 @@ These examples show how to create a [custom plugin](https://redocly.com/docs/cli
 
 First the main plugin code in `x-code-sample-checks.js`:
 
-```js 
-const CheckSDKCoverage = require('./rules/check-sdk-coverage.js');
+```js
+import CheckSDKCoverage from "./rules/check-sdk-coverage.js";
 
-module.exports = function myRulesPlugin() {
+export default function myRulesPlugin() {
   return {
-    id: 'x-code-samples-check',
+    id: "x-code-samples-check",
     rules: {
       oas3: {
-        'check-sdk-coverage': CheckSDKCoverage
+        "check-sdk-coverage": CheckSDKCoverage,
       },
     },
   };
-};
+}
 ```
 
 Save this file and import the plugin by adding the following example to `redocly.yaml`:
 
 ```yaml
 plugins:
-- ./x-code-sample-checks.js
+  - ./x-code-sample-checks.js
 ```
 
 ### Rule - Check SDK Coverage
@@ -59,37 +60,38 @@ plugins:
 The main functionality of the plugin is in this file `check-dks-coverage.js`, which is as follows:
 
 ```js
-module.exports = CheckSDKCoverage;
+const sdkLanguages = ["bash", "javascript", "python", "ruby", "java", "kotlin"];
 
-const sdkLanguages = ['bash', 'javascript', 'python', 'ruby', 'java', 'kotlin'];
-
-function CheckSDKCoverage () {
-    return {
-        XCodeSampleList: {
-          enter(codeSampleList, ctx) {
-            // Make sure the list contains at least one bash sample
-            const hasBashSample = codeSampleList.some((codeSample) => {
-              return codeSample.lang === 'bash';
-            });
-            //check for the other SDK languages by making an array of the lang fields from the code samples
-            const langArray = codeSampleList.map((codeSample) => {
-              return codeSample.lang;
-            });
-            //compare the sdkLanguages array with the langArray to find the missing languages, and save them to an array
-            const missingLanguages = sdkLanguages.filter((lang) => {
-                return !langArray.includes(lang);
-            }
-            );
-            //if there are missing languages, report them as warnings
-            // might want to make this less verbose later
-            if (missingLanguages.length > 0) {
-            ctx.report({
-                message: `Only ${langArray.length} code samples: ${langArray.join(', ')} but is missing the following SDK languages: ${missingLanguages.join(', ')}`,
-            });
-            }
-            }
+export default function CheckSDKCoverage() {
+  return {
+    XCodeSampleList: {
+      enter(codeSampleList, ctx) {
+        // Make sure the list contains at least one bash sample
+        const hasBashSample = codeSampleList.some((codeSample) => {
+          return codeSample.lang === "bash";
+        });
+        //check for the other SDK languages by making an array of the lang fields from the code samples
+        const langArray = codeSampleList.map((codeSample) => {
+          return codeSample.lang;
+        });
+        //compare the sdkLanguages array with the langArray to find the missing languages, and save them to an array
+        const missingLanguages = sdkLanguages.filter((lang) => {
+          return !langArray.includes(lang);
+        });
+        //if there are missing languages, report them as warnings
+        // might want to make this less verbose later
+        if (missingLanguages.length > 0) {
+          ctx.report({
+            message: `Only ${langArray.length} code samples: ${langArray.join(
+              ", "
+            )} but is missing the following SDK languages: ${missingLanguages.join(
+              ", "
+            )}`,
+          });
         }
-    };
+      },
+    },
+  };
 }
 ```
 
@@ -112,14 +114,10 @@ The following sections show part of an API description, and the expected output.
 post:
   operationId: custom_auth_flow
   summary: Custom Authentication
-  description: 
-    [...] # Omitted for brevity
-  security:
-    [...] # Omitted for brevity
-  requestBody:
-    [...] # Omitted for brevity
-  responses:
-    [...] # Omitted for brevity
+  description: [...] # Omitted for brevity
+  security: [...] # Omitted for brevity
+  requestBody: [...] # Omitted for brevity
+  responses: [...] # Omitted for brevity
   x-code-samples:
     - lang: bash
       label: cURL
@@ -149,4 +147,3 @@ post:
 api-docs/paths/auth/custom.yaml:
   435:5  error    x-code-samples-check/check-sdk-coverage  Only 5 code samples: bash, ruby, python, java, kotlin but is missing the following SDK languages: javascript
 ```
-

--- a/custom-plugin-rules/code-sample-checks/check-sdk-coverage.js
+++ b/custom-plugin-rules/code-sample-checks/check-sdk-coverage.js
@@ -1,33 +1,34 @@
-module.exports = CheckSDKCoverage;
-
 // If you have different SDK languages edit this array
-const sdkLanguages = ['bash', 'javascript', 'python', 'ruby', 'java', 'kotlin'];
+const sdkLanguages = ["bash", "javascript", "python", "ruby", "java", "kotlin"];
 
-function CheckSDKCoverage () {
-    return {
-        XCodeSampleList: {
-          enter(codeSampleList, ctx) {
-            // Make sure the list contains at least one bash sample
-            const hasBashSample = codeSampleList.some((codeSample) => {
-              return codeSample.lang === 'bash';
-            });
-            //check for the other SDK languages by making an array of the lang fields from the code samples
-            const langArray = codeSampleList.map((codeSample) => {
-              return codeSample.lang;
-            });
-            //compare the sdkLanguages array with the langArray to find the missing languages, and save them to an array
-            const missingLanguages = sdkLanguages.filter((lang) => {
-                return !langArray.includes(lang);
-            }
-            );
-            //if there are missing languages, report them as warnings
-            // might want to make this less verbose later
-            if (missingLanguages.length > 0) {
-            ctx.report({
-                message: `Only ${langArray.length} code samples: ${langArray.join(', ')} but is missing the following SDK languages: ${missingLanguages.join(', ')}`,
-            });
-            }
-            }
+export default function CheckSDKCoverage() {
+  return {
+    XCodeSampleList: {
+      enter(codeSampleList, ctx) {
+        // Make sure the list contains at least one bash sample
+        const hasBashSample = codeSampleList.some((codeSample) => {
+          return codeSample.lang === "bash";
+        });
+        //check for the other SDK languages by making an array of the lang fields from the code samples
+        const langArray = codeSampleList.map((codeSample) => {
+          return codeSample.lang;
+        });
+        //compare the sdkLanguages array with the langArray to find the missing languages, and save them to an array
+        const missingLanguages = sdkLanguages.filter((lang) => {
+          return !langArray.includes(lang);
+        });
+        //if there are missing languages, report them as warnings
+        // might want to make this less verbose later
+        if (missingLanguages.length > 0) {
+          ctx.report({
+            message: `Only ${langArray.length} code samples: ${langArray.join(
+              ", "
+            )} but is missing the following SDK languages: ${missingLanguages.join(
+              ", "
+            )}`,
+          });
         }
-    };
+      },
+    },
+  };
 }

--- a/custom-plugin-rules/code-sample-checks/x-code-sample-checks.js
+++ b/custom-plugin-rules/code-sample-checks/x-code-sample-checks.js
@@ -1,12 +1,12 @@
-const CheckSDKCoverage = require('./rules/check-sdk-coverage.js');
+import CheckSDKCoverage from "./rules/check-sdk-coverage.js";
 
-module.exports = function myRulesPlugin() {
+export default function myRulesPlugin() {
   return {
-    id: 'x-code-samples-check',
+    id: "x-code-samples-check",
     rules: {
       oas3: {
-        'check-sdk-coverage': CheckSDKCoverage
+        "check-sdk-coverage": CheckSDKCoverage,
       },
     },
   };
-};
+}

--- a/custom-plugin-rules/default-enum-match/README.md
+++ b/custom-plugin-rules/default-enum-match/README.md
@@ -1,6 +1,7 @@
 # Default is an Enum
 
 Authors:
+
 - [@hawkeyexl](https://github.com/hawkeyexl) Manny Silva ([Doc Detective](https://doc-detective.com))
 
 ## What this does and why
@@ -15,7 +16,7 @@ Update your Redocly configuration file to include the plugin and rule. Update pa
 
 ```yaml
 plugins:
-  - './default-enum-plugin.js'
+  - ./default-enum-plugin.js
 
 rules:
   default-enum/default-enum-match: error
@@ -25,23 +26,23 @@ rules:
 
 The plugin defines the rule and returns it. Update paths as necessary.
 
-```js 
-module.exports = function myRulesPlugin() {
+```js
+export default function myRulesPlugin() {
   return {
-    id: 'default-enum',
+    id: "default-enum",
     rules: {
       oas3: {
-        'default-enum-match': DefaultEnumMatch,
+        "default-enum-match": DefaultEnumMatch,
       },
       arazzo: {
-        'default-enum-match': DefaultEnumMatch,
+        "default-enum-match": DefaultEnumMatch,
       },
       async3: {
-        'default-enum-match': DefaultEnumMatch,
-      }
+        "default-enum-match": DefaultEnumMatch,
+      },
     },
   };
-};
+}
 
 function DefaultEnumMatch() {
   return {
@@ -69,12 +70,12 @@ Given an OpenAPI description with the following schema:
 
 ```yaml
 color:
-    type: string
-    enum:
-      - blue
-      - red
-      - yellow
-    default: green
+  type: string
+  enum:
+    - blue
+    - red
+    - yellow
+  default: green
 ```
 
 You get the following output:

--- a/custom-plugin-rules/default-enum-match/default-enum-plugin.js
+++ b/custom-plugin-rules/default-enum-match/default-enum-plugin.js
@@ -1,19 +1,19 @@
-module.exports = function myRulesPlugin() {
+export default function myRulesPlugin() {
   return {
-    id: 'default-enum',
+    id: "default-enum",
     rules: {
       oas3: {
-        'default-enum-match': DefaultEnumMatch,
+        "default-enum-match": DefaultEnumMatch,
       },
       arazzo: {
-        'default-enum-match': DefaultEnumMatch,
+        "default-enum-match": DefaultEnumMatch,
       },
       async3: {
-        'default-enum-match': DefaultEnumMatch,
-      }
+        "default-enum-match": DefaultEnumMatch,
+      },
     },
   };
-};
+}
 
 function DefaultEnumMatch() {
   return {

--- a/custom-plugin-rules/markdown-validator/README.md
+++ b/custom-plugin-rules/markdown-validator/README.md
@@ -1,8 +1,8 @@
 # Validate Markdown descriptions
 
 Authors:
+
 - [`@lornajane`](https://github.com/lornajane) Lorna Mitchell (Redocly)
- 
 
 ## What this does and why
 
@@ -40,22 +40,24 @@ npm install
 The entry point for the plugin code is in `openapi-markdown.js`:
 
 ```js
-const ValidateMarkdown = require('./rule-validate-markdown.js');
+import ValidateMarkdown from "./rule-validate-markdown.js";
 
-module.exports = {
-  id: 'openapi-markdown',
-  rules: {
-    oas3: {
-      'validate': ValidateMarkdown,
+export default function plugin() {
+  return {
+    id: "openapi-markdown",
+    rules: {
+      oas3: {
+        validate: ValidateMarkdown,
     }
-  }
+  };
 }
 ```
 
 The rule itself is in `rule-validate-markdown.js`:
 
 ```js
-const markdownlint = require("markdownlint");
+import markdownlint from "markdownlint";
+
 const config = {
   // the list is here https://github.com/DavidAnson/markdownlint#rules--aliases
   MD013: { line_length: 120 },
@@ -73,7 +75,7 @@ function checkString(description, ctx) {
 
   try {
     const lintResults = markdownlint.sync(options);
-    
+
     if (lintResults.desc.length) {
       // desc is the key in the options.strings object
       let lines = description.split("\n");
@@ -84,7 +86,7 @@ function checkString(description, ctx) {
         // add line number context for longer entries
         if (desc.lineNumber > 1) {
           const charsByError = lines[desc.lineNumber].substring(0, 20);
-          message = `${message} (near: ${charsByError} ...)`
+          message = `${message} (near: ${charsByError} ...)`;
         }
 
         ctx.report({
@@ -98,7 +100,7 @@ function checkString(description, ctx) {
   }
 }
 
-function ValidateMarkdown() {
+export default function ValidateMarkdown() {
   console.log("OpenAPI Markdown: validate");
   return {
     Info: {
@@ -131,17 +133,15 @@ function ValidateMarkdown() {
     },
   };
 }
-
-module.exports = ValidateMarkdown;
 ```
 
-To control the markdown validation rules in use, edit the config at the top of the file. 
+To control the markdown validation rules in use, edit the config at the top of the file.
 
 Bring the plugin into your `redocly.yaml` file like this:
 
 ```yaml
 plugins:
-  - './openapi-markdown.js'
+  - ./openapi-markdown.js
 
 rules:
   openapi-markdown/validate: warn
@@ -155,7 +155,7 @@ Given an OpenAPI description with these opening lines:
 
 ```yaml
 openapi: 3.1.0
-info: 
+info:
   title: Redocly Museum API
   description: |-
     A fake, but awesome Museum API for interacting with museum services and information.

--- a/custom-plugin-rules/markdown-validator/openapi-markdown.js
+++ b/custom-plugin-rules/markdown-validator/openapi-markdown.js
@@ -1,10 +1,12 @@
-const ValidateMarkdown = require("./rule-validate-markdown.js");
+import ValidateMarkdown from "./rule-validate-markdown.js";
 
-module.exports = {
-  id: "openapi-markdown",
-  rules: {
-    oas3: {
-      validate: ValidateMarkdown,
+export default function plugin() {
+  return {
+    id: "openapi-markdown",
+    rules: {
+      oas3: {
+        validate: ValidateMarkdown,
+      },
     },
-  },
-};
+  };
+}

--- a/custom-plugin-rules/markdown-validator/rule-validate-markdown.js
+++ b/custom-plugin-rules/markdown-validator/rule-validate-markdown.js
@@ -1,4 +1,5 @@
-const markdownlint = require("markdownlint");
+import markdownlint from "markdownlint";
+
 const config = {
   // the list is here https://github.com/DavidAnson/markdownlint#rules--aliases
   MD013: { line_length: 120 },
@@ -16,7 +17,7 @@ function checkString(description, ctx) {
 
   try {
     const lintResults = markdownlint.sync(options);
-    
+
     if (lintResults.desc.length) {
       // desc is the key in the options.strings object
       let lines = description.split("\n");
@@ -28,7 +29,7 @@ function checkString(description, ctx) {
         if (desc.lineNumber > 1) {
           // computer counts from zero, humans count from 1
           const charsByError = lines[desc.lineNumber - 1].substring(0, 20);
-          message = `${message} (near: ${charsByError} ...)`
+          message = `${message} (near: ${charsByError} ...)`;
         }
 
         ctx.report({
@@ -42,7 +43,7 @@ function checkString(description, ctx) {
   }
 }
 
-function ValidateMarkdown() {
+export default function ValidateMarkdown() {
   console.log("OpenAPI Markdown: validate");
   return {
     Info: {
@@ -75,5 +76,3 @@ function ValidateMarkdown() {
     },
   };
 }
-
-module.exports = ValidateMarkdown;

--- a/custom-plugins/sorting/README.md
+++ b/custom-plugins/sorting/README.md
@@ -11,18 +11,18 @@ When Redocly only made API documentation tools, the sorting changes were made as
 But now we make more complex tools, and many API pipelines have more than just docs in them too - so these operations are more commonly done with a decorator to transform the API description; then it can be used with any tools.
 
 Redocly CLI has a [`tags-alphabetical`](https://redocly.com/docs/cli/rules/tags-alphabetical) rule to error if the `tags` section isn't in alphabetical order by `name`.
-This plugin adds some additional *rules* for checking sort orders.
+This plugin adds some additional _rules_ for checking sort orders.
 
 - `method-sort` rule to put your methods in the desired order. The default is `["post", "patch", "put", "get", "delete"]`, but you can supply your own with an `order` parameter.
 - `property-sort` rule to sort properties either alphabetically with `order: alpha` (the default sort order for this rule) or with `order: required` to put the required properties first.
 
-The plugin also includes *decorators* to sort your OpenAPI descriptions, perhaps to allow an existing OpenAPI description to be easily updated to meet the expectations of the sorting rules.
+The plugin also includes _decorators_ to sort your OpenAPI descriptions, perhaps to allow an existing OpenAPI description to be easily updated to meet the expectations of the sorting rules.
 Here's a full list of the sorting features:
 
 - `methods`: sorts methods consistently in the order you supply (or `GET`, `POST`, `PUT`, `PATCH` and `DELETE` by default), with any unsorted methods appended afterwards
 - `enums-alphabetical`: sorts the options for an enum field alphabetically
 - `properties-alphabetical`: sorts object properties in schemas alphabetically
-- `properties-required-first`: puts the required properties at the top of the list (run this *after* any other property sorting decorators)
+- `properties-required-first`: puts the required properties at the top of the list (run this _after_ any other property sorting decorators)
 - `tags-alphabetical`: sorts tags alphabetically
 
 ## Code
@@ -30,15 +30,15 @@ Here's a full list of the sorting features:
 Here's the main plugin entrypoint, it's in `sorting.js`:
 
 ```javascript
-const SortTagsAlphabetically = require("./sort-tags");
-const SortEnumsAlphabetically = require("./sort-enums");
-const SortMethods = require("./sort-methods");
-const SortPropertiesAlphabetically = require("./sort-props-alpha");
-const SortPropertiesRequiredFirst = require("./sort-props-required");
-const RuleSortMethods = require("./rule-sort-methods");
-const RuleSortProps = require("./rule-sort-props");
+import SortTagsAlphabetically from "./sort-tags";
+import SortEnumsAlphabetically from "./sort-enums";
+import SortMethods from "./sort-methods";
+import SortPropertiesAlphabetically from "./sort-props-alpha";
+import SortPropertiesRequiredFirst from "./sort-props-required";
+import RuleSortMethods from "./rule-sort-methods";
+import RuleSortProps from "./rule-sort-props";
 
-module.exports = function Sorting() {
+export default function Sorting() {
   return {
     id: "sorting",
     rules: {
@@ -57,7 +57,7 @@ module.exports = function Sorting() {
       },
     },
   };
-};
+}
 ```
 
 Each of the available rules/decorators is in its own file, rather than copying them here, you can view them in the same directory as this `README`:

--- a/custom-plugins/sorting/rule-sort-methods.js
+++ b/custom-plugins/sorting/rule-sort-methods.js
@@ -1,4 +1,4 @@
-function RuleSortMethods({ order }) {
+export default function RuleSortMethods({ order }) {
   console.log("check method order");
   return {
     PathItem: {
@@ -32,5 +32,3 @@ function RuleSortMethods({ order }) {
     },
   };
 }
-
-module.exports = RuleSortMethods;

--- a/custom-plugins/sorting/rule-sort-props.js
+++ b/custom-plugins/sorting/rule-sort-props.js
@@ -1,4 +1,4 @@
-function RuleSortProps({ type }) {
+export default function RuleSortProps({ type }) {
   let sortType = "alpha"; // default
   const supportedSortTypes = ["alpha", "required"];
   if (type && supportedSortTypes.includes(type)) {
@@ -68,5 +68,3 @@ function RuleSortProps({ type }) {
     },
   };
 }
-
-module.exports = RuleSortProps;

--- a/custom-plugins/sorting/sort-enums.js
+++ b/custom-plugins/sorting/sort-enums.js
@@ -1,6 +1,4 @@
-module.exports = SortEnumsAlphabetically;
-
-function SortEnumsAlphabetically() {
+export default function SortEnumsAlphabetically() {
   console.log("re-ordering enums: alphabetical");
   return {
     Schema: {

--- a/custom-plugins/sorting/sort-methods.js
+++ b/custom-plugins/sorting/sort-methods.js
@@ -1,6 +1,4 @@
-module.exports = SortMethods;
-
-function SortMethods({ order }) {
+export default function SortMethods({ order }) {
   console.log("re-ordering methods");
   return {
     PathItem: {

--- a/custom-plugins/sorting/sort-props-alpha.js
+++ b/custom-plugins/sorting/sort-props-alpha.js
@@ -1,6 +1,4 @@
-module.exports = SortPropertiesAlphabetically;
-
-function SortPropertiesAlphabetically() {
+export default function SortPropertiesAlphabetically() {
   console.log("re-ordering properties: alphabetical");
   return {
     Schema: {

--- a/custom-plugins/sorting/sort-props-required.js
+++ b/custom-plugins/sorting/sort-props-required.js
@@ -1,6 +1,4 @@
-module.exports = SortPropertiesRequiredFirst;
-
-function SortPropertiesRequiredFirst() {
+export default function SortPropertiesRequiredFirst() {
   console.log("re-ordering properties: required first");
   return {
     Schema: {

--- a/custom-plugins/sorting/sort-tags.js
+++ b/custom-plugins/sorting/sort-tags.js
@@ -1,6 +1,4 @@
-module.exports = SortTagsAlphabetically;
-
-function SortTagsAlphabetically() {
+export default function SortTagsAlphabetically() {
   console.log("re-ordering tags: alphabetical");
   return {
     TagList: {

--- a/custom-plugins/sorting/sorting.js
+++ b/custom-plugins/sorting/sorting.js
@@ -1,12 +1,12 @@
-const SortTagsAlphabetically = require("./sort-tags");
-const SortEnumsAlphabetically = require("./sort-enums");
-const SortMethods = require("./sort-methods");
-const SortPropertiesAlphabetically = require("./sort-props-alpha");
-const SortPropertiesRequiredFirst = require("./sort-props-required");
-const RuleSortMethods = require("./rule-sort-methods");
-const RuleSortProps = require("./rule-sort-props");
+import SortTagsAlphabetically from "./sort-tags";
+import SortEnumsAlphabetically from "./sort-enums";
+import SortMethods from "./sort-methods";
+import SortPropertiesAlphabetically from "./sort-props-alpha";
+import SortPropertiesRequiredFirst from "./sort-props-required";
+import RuleSortMethods from "./rule-sort-methods";
+import RuleSortProps from "./rule-sort-props";
 
-module.exports = function Sorting() {
+export default function Sorting() {
   return {
     id: "sorting",
     rules: {
@@ -25,4 +25,4 @@ module.exports = function Sorting() {
       },
     },
   };
-};
+}

--- a/miscellaneous/reorder-bundled-description-properties/README.md
+++ b/miscellaneous/reorder-bundled-description-properties/README.md
@@ -16,8 +16,8 @@ For that purpose, you can write a simple `JavaScript` script code similar to the
 /* reorder.js */
 
 // Import the necessary modules
-const fs = require("fs");
-const { parseYaml, stringifyYaml } = require("@redocly/openapi-core");
+import fs from "fs";
+import { parseYaml, stringifyYaml } from "@redocly/openapi-core";
 
 // Define the function to reorder the properties
 const reorder = (root) => {

--- a/miscellaneous/reorder-bundled-description-properties/reorder.js
+++ b/miscellaneous/reorder-bundled-description-properties/reorder.js
@@ -1,5 +1,5 @@
-const fs = require("fs");
-const { parseYaml, stringifyYaml } = require("@redocly/openapi-core");
+import fs from "fs";
+import { parseYaml, stringifyYaml } from "@redocly/openapi-core";
 
 const reorder = (root) => {
   const { components, openapi, ...rest } = root;

--- a/rulesets/spec-compliant/README.md
+++ b/rulesets/spec-compliant/README.md
@@ -1,8 +1,8 @@
 # spec-compliant ruleset
 
 Authors:
+
 - `@CidTori`
- 
 
 ## What this does and why
 
@@ -18,7 +18,8 @@ You can use it in your `redocly.yaml` wih [`extends`](https://redocly.com/docs/c
 
 ```yaml
 rules:
-  spec: error
+  struct: error
+  nullable-type-sibling: error
   spec-strict-refs: error
   no-undefined-server-variable: error
   path-not-include-query: error
@@ -41,7 +42,8 @@ rules:
 
 Here is why each rule is included:
 
-- `spec`: [obviously](https://redocly.com/docs/cli/rules/spec/#api-design-principles)
+- `struct`: [ensures structural correctness](https://redocly.com/docs/cli/rules/spec/#api-design-principles)
+- `nullable-type-sibling`: [ensures compliance with the OpenAPI 3.0 spec](https://redocly.com/docs/cli/v2/rules/oas/nullable-type-sibling)
 - `spec-strict-refs`: ["strict adherence to the specifications"](https://redocly.com/docs/cli/rules/spec-strict-refs/#api-design-principles)
 - `no-undefined-server-variable`: ["it's an error with the specification"](https://redocly.com/docs/cli/rules/no-undefined-server-variable/#api-design-principles)
 - `path-declaration-must-exist`: ["This rule is for spec correctness"](https://redocly.com/docs/cli/rules/path-declaration-must-exist/#api-design-principles)
@@ -57,6 +59,6 @@ Here is why each rule is included:
 - `no-invalid-schema-examples`: ["It is RECOMMENDED that these values be valid against the associated schema."](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-9.5)
 - `no-example-value-and-externalValue`: ["The value field and externalValue field are mutually exclusive."](https://spec.openapis.org/oas/latest.html#fixed-fields-15)
 - `no-unresolved-refs` (debatable): ["The referenced structure MUST be in the form of a Path Item Object."](https://spec.openapis.org/oas/latest.html#fixed-fields-6)
-- `spec-components-invalid-map-name`: ["All the fixed fields declared above are objects that MUST use keys that match the regular expression: ^\[a-zA-Z0-9\.\-_\]+$."](https://spec.openapis.org/oas/latest.html#fixed-fields-5)
+- `spec-components-invalid-map-name`: ["All the fixed fields declared above are objects that MUST use keys that match the regular expression: ^\[a-zA-Z0-9\.\-\_\]+$."](https://spec.openapis.org/oas/latest.html#fixed-fields-5)
 
 Please, feel free to open issues or pull requests to suggest updates or additions to this ruleset.

--- a/rulesets/spec-compliant/redocly.yaml
+++ b/rulesets/spec-compliant/redocly.yaml
@@ -1,5 +1,6 @@
 rules:
-  spec: error
+  struct: error
+  nullable-type-sibling: error
   spec-strict-refs: error
   no-undefined-server-variable: error
   path-not-include-query: error


### PR DESCRIPTION
Updated examples according to the changes in Reodcly CLI v2:
 
- migrated CJS to ESM 
- removed / replaced deprecations

Fixed errors in examples.

Resolves https://github.com/Redocly/redocly/issues/10604
