### PR TITLE
Request: Adding new configurable rule: `operation-operationId-exclude-OPTIONS`

### DIFF
--- a/configurable-rules/operation-operationId-exclude-OPTIONS/README.md
+++ b/configurable-rules/operation-operationId-exclude-OPTIONS/README.md
@@ -5,26 +5,11 @@ Author:
 
 ## What this does and why
 
-This rule extends the built-in rule [operation-operationId](https://redocly.com/docs/cli/rules/oas/operation-operationId) by filtering out set operations e.g. `OPTIONS`.
+This rule throws an error for all operations that are missing the `operationId` property, while filtering out specific operations that you want to exclude from this validation (e.g. `OPTIONS`).
 
 This rule can be tweaked to exclude any combination of operations, or inversely to **include** set operations. 
 
 ## Code
-
-> If you are using a ruleset that includes the `operation-operationId` rule (like `recommended`), you will need to disable this rule in order for the configurable rule to apply.
-> 
-> e.g. if your `redocly.yaml` file contains:
->
-> ```yaml
-> extends:
->   - recommended
-> ```
-> You will need to include the following snippet in the `rules` property:
->
-> ```yaml
->   rules:
->     operation-operationId: off
-> ```
 
 This rule is added to the `rules` section of your `redocly.yaml` file:
 
@@ -69,7 +54,7 @@ Alternatively, you can use the `filterInParentKeys` property to define which ope
 
 ## Examples
 
-With the rule configured with `severity: error`, the following snippet of a `GET` and `POST` operations will trigger this rule & display an error:
+With the rule configured with `severity: error`, the following snippet of a `GET` and `POST` operations will trigger this rule and display an error:
 
 ```yaml
 openapi: 3.1.0
@@ -77,15 +62,11 @@ info: {}
 paths:
   /example:
     get: # Error: Operation is missing 'operationId' property. Rule: operation-operationId-exclude-OPTIONS
-      security:
-        - api_key: []
       responses:
         '200':
           content: {}
 
     post: # Error: Operation is missing 'operationId' property. Rule: operation-operationId-exclude-OPTIONS
-      security:
-        - api_key: []
       responses:
         '201':
           content: {}
@@ -94,6 +75,21 @@ paths:
       responses:
         '204':
           content: {}
+```
+
+**Note:** If you are using a ruleset that includes the [operation-operationId](https://redocly.com/docs/cli/rules/oas/operation-operationId) rule (like `recommended`), you will need to disable this rule in order for the configurable rule to apply.
+
+If your `redocly.yaml` file contains:
+
+```yaml
+extends:
+  - recommended
+```
+You will need to include the following snippet in the `rules` property:
+
+```yaml
+rules:
+  operation-operationId: off
 ```
 
 ## References

--- a/configurable-rules/operation-operationId-exclude-OPTIONS/README.md
+++ b/configurable-rules/operation-operationId-exclude-OPTIONS/README.md
@@ -1,0 +1,154 @@
+# Variant of the `operation-operationId` rule that excludes `OPTIONS` operations
+
+Author:
+- [@nickcorby](https://github.com/nickcorby)
+
+## What this does and why
+
+This rule extends the built-in rule [operation-operationId](https://redocly.com/docs/cli/rules/oas/operation-operationId) by filtering out set operations e.g. `OPTIONS`.
+
+This rule can be tweaked to exclude any combination of operations, or inversely to **include** set operations. 
+
+## Code
+
+> If you are using a ruleset that includes the `operation-operationId` rule (like `recommended`), you will need to disable this rule in order for the configurable rule to apply.
+> 
+> e.g. if your `redocly.yaml` file contains:
+>
+> ```yaml
+> extends:
+>   - recommended
+> ```
+> You will need to include the following snippet in the `rules` property:
+>
+> ```yaml
+>   rules:
+>     operation-operationId: off
+> ```
+
+This rule is added to your `redocly.yaml` file:
+
+```yaml
+rule/operation-operationId-exclude-OPTIONS:
+  subject:
+    type: Operation
+    filterOutParentKeys:
+      - options
+  assertions:
+    required:
+      - operationId
+  message: Operation is missing 'operationId' property.
+  severity: error
+```
+
+The `filterOutParentKeys` property allows you to define which operations you would like to exclude from the rule:
+
+```yaml
+    type: Operation
+    filterOutParentKeys:
+      - options
+```
+
+This can be extended to multiple operations:
+
+```yaml
+    type: Operation
+    filterOutParentKeys:
+      - options
+      - delete
+```
+
+Alternatively, you can use the `filterInParentKeys` property to define which operations you would like to include in the rule:
+
+```yaml
+    type: Operation
+    filterInParentKeys:
+      - get
+      - post
+```
+
+## Examples
+
+With the rule configured with `severity: error`, the following snippet of a `GET` operation will trigger this rule & display an error:
+
+```yaml
+get:
+  tags:
+  - Endpoint
+  summary: "Example endpoint."
+  parameters:
+  - name: "Authorization"
+    in: "header"
+    description: "Auth Token"
+    required: true
+    schema:
+      type: "string"
+  responses:
+    "200":
+      description: "200 response"
+      headers:
+        Access-Control-Allow-Origin:
+          schema:
+            type: "string"
+      content:
+        application/json:
+          schema:
+            $ref: ../models/200Response.yaml
+    "400":
+      description: "400 response"
+      headers:
+        Access-Control-Allow-Origin:
+          schema:
+            type: "string"
+      content:
+        application/json:
+          schema:
+            $ref: ../models/ErrorResponse.yaml
+  security:
+  - Authorizer: []
+  - api_key: []
+```
+
+However, the following snippet of an `OPTIONS` operation **won't** trigger the rule:
+
+```yaml
+options:
+  tags:
+  - Endpoint
+  summary: "Example endpoint."
+  parameters:
+  - name: "Authorization"
+    in: "header"
+    description: "Auth Token"
+    required: true
+    schema:
+      type: "string"
+  responses:
+    "200":
+      description: "200 response"
+      headers:
+        Access-Control-Allow-Origin:
+          schema:
+            type: "string"
+      content:
+        application/json:
+          schema:
+            $ref: ../models/200Response.yaml
+    "400":
+      description: "400 response"
+      headers:
+        Access-Control-Allow-Origin:
+          schema:
+            type: "string"
+      content:
+        application/json:
+          schema:
+            $ref: ../models/ErrorResponse.yaml
+  security:
+  - Authorizer: []
+  - api_key: []
+```
+
+## References
+
+Assisted by [AlbinaBlazhko17](https://github.com/AlbinaBlazhko17)

--- a/configurable-rules/operation-operationId-exclude-OPTIONS/README.md
+++ b/configurable-rules/operation-operationId-exclude-OPTIONS/README.md
@@ -26,7 +26,7 @@ This rule can be tweaked to exclude any combination of operations, or inversely 
 >     operation-operationId: off
 > ```
 
-This rule is added to your `redocly.yaml` file:
+This rule is added to the `rules` section of your `redocly.yaml` file:
 
 ```yaml
 rule/operation-operationId-exclude-OPTIONS:
@@ -69,84 +69,31 @@ Alternatively, you can use the `filterInParentKeys` property to define which ope
 
 ## Examples
 
-With the rule configured with `severity: error`, the following snippet of a `GET` operation will trigger this rule & display an error:
+With the rule configured with `severity: error`, the following snippet of a `GET` and `POST` operations will trigger this rule & display an error:
 
 ```yaml
-get:
-  tags:
-  - Endpoint
-  summary: "Example endpoint."
-  parameters:
-  - name: "Authorization"
-    in: "header"
-    description: "Auth Token"
-    required: true
-    schema:
-      type: "string"
-  responses:
-    "200":
-      description: "200 response"
-      headers:
-        Access-Control-Allow-Origin:
-          schema:
-            type: "string"
-      content:
-        application/json:
-          schema:
-            $ref: ../models/200Response.yaml
-    "400":
-      description: "400 response"
-      headers:
-        Access-Control-Allow-Origin:
-          schema:
-            type: "string"
-      content:
-        application/json:
-          schema:
-            $ref: ../models/ErrorResponse.yaml
-  security:
-  - Authorizer: []
-  - api_key: []
-```
+openapi: 3.1.0
+info: {}
+paths:
+  /example:
+    get: # Error: Operation is missing 'operationId' property. Rule: operation-operationId-exclude-OPTIONS
+      security:
+        - api_key: []
+      responses:
+        '200':
+          content: {}
 
-However, the following snippet of an `OPTIONS` operation **won't** trigger the rule:
+    post: # Error: Operation is missing 'operationId' property. Rule: operation-operationId-exclude-OPTIONS
+      security:
+        - api_key: []
+      responses:
+        '201':
+          content: {}
 
-```yaml
-options:
-  tags:
-  - Endpoint
-  summary: "Example endpoint."
-  parameters:
-  - name: "Authorization"
-    in: "header"
-    description: "Auth Token"
-    required: true
-    schema:
-      type: "string"
-  responses:
-    "200":
-      description: "200 response"
-      headers:
-        Access-Control-Allow-Origin:
-          schema:
-            type: "string"
-      content:
-        application/json:
-          schema:
-            $ref: ../models/200Response.yaml
-    "400":
-      description: "400 response"
-      headers:
-        Access-Control-Allow-Origin:
-          schema:
-            type: "string"
-      content:
-        application/json:
-          schema:
-            $ref: ../models/ErrorResponse.yaml
-  security:
-  - Authorizer: []
-  - api_key: []
+    options: # No error
+      responses:
+        '204':
+          content: {}
 ```
 
 ## References

--- a/configurable-rules/operation-operationId-exclude-OPTIONS/redocly.yaml
+++ b/configurable-rules/operation-operationId-exclude-OPTIONS/redocly.yaml
@@ -1,0 +1,10 @@
+rule/operation-operationId-exclude-OPTIONS:
+  subject:
+    type: Operation
+    filterOutParentKeys:
+      - options
+  assertions:
+    required:
+      - operationId
+  message: Operation is missing 'operationId' property.
+  severity: error


### PR DESCRIPTION
As suggested by [AlbinaBlazhko17](https://github.com/AlbinaBlazhko17), I've added a configurable rule to the cookbook to allow you to emulate the `operation-operationId` rule with the added capability of filtering by operation type (in this case, `OPTIONS`).

Please let me know if anything needs to be tweaked, and thank you again for being so responsive & offering assistance! We're starting a new IaC project at work and Redocly CLI has been instrumental in defining our APIs. This is just one feature that has provided huge benefit for us.